### PR TITLE
Add CoinGecko ID, CoinMarketCap ID, and DTI for chains on mainnet

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -327,6 +327,9 @@ type ChainConfig struct {
 	NoGasFees            bool            `yaml:"no_gas_fees,omitempty"`
 	Disabled             *bool           `yaml:"disabled,omitempty"`
 	ExplorerUrls         ExplorerUrls    `yaml:"explorer_urls"`
+	CoinGeckoId          string          `yaml:"coingecko_id,omitempty"`
+	CoinMarketCapId      string          `yaml:"coinmarketcap_id,omitempty"`
+	Dti                  string          `yaml:"dti,omitempty"`
 
 	ConfirmationsFinal int `yaml:"confirmations_final,omitempty"`
 

--- a/factory/defaults/chains/mainnet.yaml
+++ b/factory/defaults/chains/mainnet.yaml
@@ -9,6 +9,7 @@ chains:
     decimals: 12
     indexer_type: rpc
     polling_period: 15m
+    coingecko_id: acala
   APTOS:
     chain: APTOS
     driver: aptos
@@ -19,6 +20,9 @@ chains:
     indexer_url: https://indexer.mainnet.aptoslabs.com
     indexer_type: aptos
     polling_period: 8m
+    coingecko_id: aptos
+    coinmarketcap_id: 141
+    dti: SSFZXXTDD
   ATOM:
     chain: ATOM
     driver: cosmos
@@ -32,6 +36,9 @@ chains:
     decimals: 6
     indexer_type: cosmos
     polling_period: 5m
+    coingecko_id: cosmos
+    coinmarketcap_id: 56
+    dti: J51DXB76N
   AVAX:
     chain: AVAX
     driver: evm
@@ -41,6 +48,9 @@ chains:
     decimals: 18
     indexer_type: covalent
     polling_period: 6m
+    coingecko_id: avalanche
+    coinmarketcap_id: 28
+    dti: M3Z631TN4
   ArbETH:
     chain: ArbETH
     driver: evm
@@ -51,6 +61,9 @@ chains:
     decimals: 18
     indexer_type: rpc
     polling_period: 10m
+    coingecko_id: arbitrum-one
+    coinmarketcap_id: 51
+    dti: PXW7VQ0RC
   AurETH:
     chain: AurETH
     driver: evm-legacy
@@ -60,12 +73,16 @@ chains:
     decimals: 18
     indexer_type: rpc
     polling_period: 15m
+    coingecko_id: aurora
+    coinmarketcap_id: 98
+    dti: 3555NMHK2
   BERA:
     # not yet released
     chain: BERA
     driver: evm
     chain_name: Berachain
     decimals: 18
+    coingecko_id: berachain-bera
   BCH:
     chain: BCH
     driver: bitcoin-cash
@@ -77,6 +94,9 @@ chains:
     indexer_url: https://api.blockchair.com/bitcoin-cash
     indexer_type: blockchair
     polling_period: 10m
+    coingecko_id: bitcoin-cash
+    coinmarketcap_id: 39
+    dti: J9K583ZGG
   BNB:
     chain: BNB
     driver: evm-legacy
@@ -86,6 +106,9 @@ chains:
     decimals: 18
     indexer_type: covalent
     polling_period: 6m
+    coingecko_id: binance-smart-chain
+    coinmarketcap_id: 14
+    dti: HWRGLMT9T
   BTC:
     chain: BTC
     driver: bitcoin
@@ -97,6 +120,7 @@ chains:
     indexer_url: https://api.blockchair.com/bitcoin
     indexer_type: blockchair
     polling_period: 10m
+    dti: 4H95J0R2X
   CELO:
     chain: CELO
     driver: evm
@@ -107,6 +131,9 @@ chains:
     indexer_url: https://explorer.celo.org/mainnet
     indexer_type: blockscout
     polling_period: 6m
+    coingecko_id: celo
+    coinmarketcap_id: 35
+    dti: PTN9Z5Q7D
   CHZ:
     chain: CHZ
     driver: evm-legacy
@@ -119,6 +146,8 @@ chains:
     polling_period: 6m
     disabled: true
     no_gas_fees: true
+    coinmarketcap_id: 8
+    dti: 7PDZ5890K
   CHZ2:
     chain: CHZ2
     driver: evm-legacy
@@ -129,6 +158,8 @@ chains:
     indexer_url: https://scan.chiliz.com
     indexer_type: blockscout
     polling_period: 6m
+    coingecko_id: chiliz
+    dti: GV9QD1V9M
   DOGE:
     chain: DOGE
     driver: bitcoin-legacy
@@ -142,6 +173,9 @@ chains:
     polling_period: 10m
     # DOGE is much cheaper so we set the gas price (sats/byte) to be much higher
     chain_max_gas_price: 50000000
+    coingecko_id: dogecoin
+    coinmarketcap_id: 136
+    dti: 820B7G1NL
   DOT:
     chain: DOT
     driver: substrate
@@ -149,6 +183,9 @@ chains:
     chain_name: Polkadot
     chain_prefix: "0"
     indexer_url: "https://polkadot.api.subscan.io"
+    coingecko_id: polkadot
+    coinmarketcap_id: 37
+    dti: P5B46MFPP
   ETC:
     chain: ETC
     driver: evm-legacy
@@ -159,6 +196,8 @@ chains:
     indexer_type: blockscout
     indexer_url: https://etc.blockscout.com
     polling_period: 10m
+    coingecko_id: ethereum-classic
+    dti: GWQWXVV7J
   ETH:
     chain: ETH
     driver: evm
@@ -174,6 +213,9 @@ chains:
       # KILN exit contract
       unstake_contract: "0x004c226fff73aa94b78a4df1a0e861797ba16819"
       providers: ["kiln", "twinstake"]
+    coingecko_id: ethereum
+    coinmarketcap_id: 1
+    dti: X9J9K872S
   ETHW:
     chain: ETHW
     driver: evm
@@ -183,6 +225,8 @@ chains:
     decimals: 18
     indexer_type: rpc
     polling_period: 5m
+    coingecko_id: ethereumpow
+    dti: 5C3LXSVX7
   FTM:
     chain: FTM
     driver: evm-legacy
@@ -192,6 +236,9 @@ chains:
     decimals: 18
     indexer_type: covalent
     polling_period: 6m
+    coingecko_id: fantom
+    coinmarketcap_id: 24
+    dti: WS6BZ8225
   INJ:
     chain: INJ
     driver: evmos
@@ -205,6 +252,9 @@ chains:
     decimals: 18
     indexer_type: cosmos
     polling_period: 5m
+    coingecko_id: injective
+    coinmarketcap_id: 179
+    dti: WFQSW1L5L
   KAR:
     chain: KAR
     driver: evm-legacy
@@ -214,6 +264,7 @@ chains:
     decimals: 12
     indexer_type: rpc
     polling_period: 15m
+    coingecko_id: karura
   KLAY:
     chain: KLAY
     driver: evm-legacy
@@ -225,6 +276,9 @@ chains:
     decimals: 18
     indexer_type: rpc
     polling_period: 15m
+    coingecko_id: klay-token
+    coinmarketcap_id: 26
+    dti: CNDP5R1T8
   KSM:
     chain: KSM
     driver: substrate
@@ -232,6 +286,8 @@ chains:
     chain_name: Kusama
     chain_prefix: "2"
     indexer_url: "https://kusama.api.subscan.io"
+    coingecko_id: kusama
+    dti: MXLJ762RF
   LTC:
     chain: LTC
     driver: bitcoin-legacy
@@ -243,6 +299,8 @@ chains:
     indexer_url: https://api.blockchair.com/litecoin
     indexer_type: blockchair
     polling_period: 10m
+    coingecko_id: litecoin
+    dti: WTX0G7K46
   LUNA:
     chain: LUNA
     driver: cosmos
@@ -255,6 +313,9 @@ chains:
     decimals: 6
     indexer_type: cosmos
     polling_period: 5m
+    coingecko_id: terra-2
+    coinmarketcap_id: 120
+    dti: NGXHD2ZFQ
   LUNC:
     chain: LUNC
     driver: cosmos
@@ -271,6 +332,9 @@ chains:
     decimals: 6
     indexer_type: cosmos
     polling_period: 5m
+    coingecko_id: terra
+    coinmarketcap_id: 22
+    dti: NGXHD2ZFQ
   MATIC:
     chain: MATIC
     driver: evm
@@ -283,6 +347,9 @@ chains:
     indexer_type: covalent
     polling_period: 6m
     chain_max_gas_price: 120
+    coingecko_id: polygon-pos
+    coinmarketcap_id: 25
+    dti: RQWW6J6K0
   OAS:
     chain: OAS
     driver: evm-legacy
@@ -293,6 +360,7 @@ chains:
     indexer_url: https://scan.oasys.games
     indexer_type: blockscout
     polling_period: 6m
+    coingecko_id: oasys
   OptETH:
     chain: OptETH
     driver: evm
@@ -302,6 +370,8 @@ chains:
     decimals: 18
     indexer_type: rpc
     polling_period: 15m
+    coingecko_id: optimistic-ethereum
+    coinmarketcap_id: 42
   EmROSE:
     chain: EmROSE
     driver: evm-legacy
@@ -311,6 +381,9 @@ chains:
     decimals: 18
     indexer_type: covalent
     polling_period: 6m
+    coingecko_id: oasis
+    coinmarketcap_id: 94
+    dti: NVD7LRM61
   SEI:
     chain: SEI
     driver: cosmos
@@ -324,6 +397,9 @@ chains:
     decimals: 6
     indexer_type: cosmos
     polling_period: 15m
+    coingecko_id: sei-network
+    coinmarketcap_id: 188
+    dti: P4JBC8R50
   SOL:
     chain: SOL
     driver: solana
@@ -332,6 +408,9 @@ chains:
     decimals: 9
     indexer_type: solana
     polling_period: 3m
+    coingecko_id: solana
+    coinmarketcap_id: 16
+    dti: 20J63Z4N3
   SUI:
     chain: SUI
     driver: sui
@@ -340,6 +419,9 @@ chains:
     decimals: 9
     indexer_type: rpc
     polling_period: 3m
+    coingecko_id: sui
+    coinmarketcap_id: 176
+    dti: 90KLX8GQX
   TRX:
     chain: TRX
     driver: tron
@@ -349,6 +431,9 @@ chains:
     decimals: 6
     # 200 tron fee limit
     chain_max_gas_price: 2000000000
+    coingecko_id: tron
+    coinmarketcap_id: 47
+    dti: 993D8X1FB
   TIA:
     chain: TIA
     driver: cosmos
@@ -360,6 +445,7 @@ chains:
     chain_gas_price_default: 0.1
     decimals: 6
     indexer_type: cosmos
+    coingecko_id: celestia
   XDC:
     chain: XDC
     driver: evm-legacy
@@ -370,6 +456,9 @@ chains:
     indexer_url: https://xdc.blocksscan.io
     indexer_type: blocksscan
     polling_period: 6m
+    coingecko_id: xdc-network
+    coinmarketcap_id: 163
+    dti: CCQZQXFDC
   XPLA:
     chain: XPLA
     driver: cosmos
@@ -383,6 +472,7 @@ chains:
     decimals: 18
     indexer_type: cosmos
     polling_period: 5m
+    coingecko_id: xpla
   HASH:
     chain: HASH
     driver: cosmos
@@ -406,7 +496,11 @@ chains:
     chain_prefix: "42"
     indexer_url: "https://api.subquery.network/sq/TaoStats/bittensor-dictionary"
     indexer_type: subquery
+    coingecko_id: bittensor
   TON:
     chain: TON
     driver: ton
     decimals: 9
+    coingecko_id: the-open-network
+    coinmarketcap_id: 173
+    dti: QBZLT5MT1


### PR DESCRIPTION
Not all the IDs are present in the data source, so they are not specified in the config file.