### PR TITLE
Implement Dusk Driver

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -14,13 +14,11 @@ import (
 type SignatureType string
 
 const (
-	K256Keccak = SignatureType("k256-keccak")
-	K256Sha256 = SignatureType("k256-sha256")
-	Ed255      = SignatureType("ed255")
-	Schnorr    = SignatureType("schnorr")
-
-	// TODO: Bls12_381G2Blake2
-	Bls = SignatureType("bls")
+	K256Keccak        = SignatureType("k256-keccak")
+	K256Sha256        = SignatureType("k256-sha256")
+	Ed255             = SignatureType("ed255")
+	Schnorr           = SignatureType("schnorr")
+	Bls12_381G2Blake2 = SignatureType("bls12-381-g2-blake2")
 )
 
 // NativeAsset is an asset on a blockchain used to pay gas fees.
@@ -282,7 +280,7 @@ func (driver Driver) SignatureAlgorithm() SignatureType {
 	case DriverAptos, DriverSolana, DriverSui, DriverTon, DriverSubstrate, DriverXlm:
 		return Ed255
 	case DriverDusk:
-		return Bls
+		return Bls12_381G2Blake2
 	}
 	return ""
 }

--- a/asset.go
+++ b/asset.go
@@ -299,7 +299,7 @@ func (driver Driver) PublicKeyFormat() PublicKeyFormat {
 		return Compressed
 	case DriverEVM, DriverEVMLegacy, DriverTron, DriverFilecoin:
 		return Uncompressed
-	case DriverAptos, DriverSolana, DriverSui, DriverTon, DriverSubstrate:
+	case DriverAptos, DriverSolana, DriverSui, DriverTon, DriverSubstrate, DriverDusk:
 		return Raw
 	}
 	return ""

--- a/asset.go
+++ b/asset.go
@@ -442,7 +442,11 @@ func (chain *ChainConfig) WithMinGasPrice(minGasPrice float64) *ChainConfig {
 	return chain
 }
 func (chain *ChainConfig) WithMaxGasPrice(maxGasPrice float64) *ChainConfig {
-	chain.ChainClientConfig.ChainMinGasPrice = maxGasPrice
+	chain.ChainClientConfig.ChainMaxGasPrice = maxGasPrice
+	return chain
+}
+func (chain *ChainConfig) WithFeeLimit(feeLimit AmountHumanReadable) *ChainConfig {
+	chain.FeeLimit = feeLimit
 	return chain
 }
 func (chain *ChainConfig) WithGasPriceMultiplier(multiplier float64) *ChainConfig {

--- a/asset.go
+++ b/asset.go
@@ -18,6 +18,9 @@ const (
 	K256Sha256 = SignatureType("k256-sha256")
 	Ed255      = SignatureType("ed255")
 	Schnorr    = SignatureType("schnorr")
+
+	// TODO: Bls12_381G2Blake2
+	Bls = SignatureType("bls")
 )
 
 // NativeAsset is an asset on a blockchain used to pay gas fees.
@@ -45,6 +48,7 @@ const (
 	CHZ2   = NativeAsset("CHZ2")   // Chiliz 2.0
 	DOGE   = NativeAsset("DOGE")   // Dogecoin
 	DOT    = NativeAsset("DOT")    // Polkadot
+	DUSK   = NativeAsset("DUSK")   // Dusk
 	ENJ    = NativeAsset("ENJ")    // Enjin
 	ETC    = NativeAsset("ETC")    // Ethereum Classic
 	ETH    = NativeAsset("ETH")    // Ethereum
@@ -100,6 +104,7 @@ var NativeAssetList []NativeAsset = []NativeAsset{
 	CHZ,
 	CHZ2,
 	DOT,
+	DUSK,
 	ENJ,
 	ETC,
 	ETH,
@@ -146,6 +151,7 @@ const (
 	DriverBitcoinLegacy = Driver("bitcoin-legacy")
 	DriverCosmos        = Driver("cosmos")
 	DriverCosmosEvmos   = Driver("evmos")
+	DriverDusk          = Driver("dusk")
 	DriverEVM           = Driver("evm")
 	DriverEVMLegacy     = Driver("evm-legacy")
 	DriverFilecoin      = Driver("filecoin")
@@ -261,6 +267,8 @@ func (native NativeAsset) Driver() Driver {
 		return DriverXlm
 	case FIL:
 		return DriverFilecoin
+	case DUSK:
+		return DriverDusk
 	}
 	return ""
 }
@@ -273,6 +281,8 @@ func (driver Driver) SignatureAlgorithm() SignatureType {
 		return K256Keccak
 	case DriverAptos, DriverSolana, DriverSui, DriverTon, DriverSubstrate, DriverXlm:
 		return Ed255
+	case DriverDusk:
+		return Bls
 	}
 	return ""
 }

--- a/chain/dusk/address/address.go
+++ b/chain/dusk/address/address.go
@@ -1,0 +1,32 @@
+package address
+
+import (
+	"github.com/btcsuite/btcd/btcutil/base58"
+	"github.com/cloudflare/circl/sign/bls"
+	xc "github.com/cordialsys/crosschain"
+)
+
+// AddressBuilder for Template
+type AddressBuilder struct {
+}
+
+var _ xc.AddressBuilder = AddressBuilder{}
+
+// NewAddressBuilder creates a new Template AddressBuilder
+func NewAddressBuilder(cfgI *xc.ChainBaseConfig) (xc.AddressBuilder, error) {
+	return AddressBuilder{}, nil
+}
+
+// GetAddressFromPublicKey returns an Address given a public key
+func (ab AddressBuilder) GetAddressFromPublicKey(publicKeyBytes []byte) (xc.Address, error) {
+	return xc.Address(base58.Encode(publicKeyBytes)), nil
+}
+
+func GetPublicKeyFromAddress(address xc.Address) (bls.PublicKey[bls.G2], error) {
+	bytes := base58.Decode(string(address))
+
+	var publicKey bls.PublicKey[bls.G2]
+	err := publicKey.UnmarshalBinary(bytes)
+
+	return publicKey, err
+}

--- a/chain/dusk/address/address_test.go
+++ b/chain/dusk/address/address_test.go
@@ -1,0 +1,24 @@
+package address_test
+
+import (
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/chain/template/address"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAddressBuilder(t *testing.T) {
+
+	builder, err := address.NewAddressBuilder(xc.NewChainConfig("XYZ").Base())
+	require.NotNil(t, builder)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestGetAddressFromPublicKey(t *testing.T) {
+
+	builder, _ := address.NewAddressBuilder(xc.NewChainConfig("XYZ").Base())
+	address, err := builder.GetAddressFromPublicKey([]byte{})
+	require.Equal(t, xc.Address(""), address)
+	require.EqualError(t, err, "not implemented")
+}

--- a/chain/dusk/address/address_test.go
+++ b/chain/dusk/address/address_test.go
@@ -1,24 +1,45 @@
 package address_test
 
 import (
+	"encoding/hex"
 	"testing"
 
+	"github.com/cloudflare/circl/sign/bls"
 	xc "github.com/cordialsys/crosschain"
-	"github.com/cordialsys/crosschain/chain/template/address"
+	"github.com/cordialsys/crosschain/chain/dusk/address"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewAddressBuilder(t *testing.T) {
-
-	builder, err := address.NewAddressBuilder(xc.NewChainConfig("XYZ").Base())
+	builder, err := address.NewAddressBuilder(xc.NewChainConfig("DUSK").Base())
 	require.NotNil(t, builder)
-	require.EqualError(t, err, "not implemented")
+	require.NoError(t, err)
 }
 
 func TestGetAddressFromPublicKey(t *testing.T) {
-
 	builder, _ := address.NewAddressBuilder(xc.NewChainConfig("XYZ").Base())
-	address, err := builder.GetAddressFromPublicKey([]byte{})
-	require.Equal(t, xc.Address(""), address)
-	require.EqualError(t, err, "not implemented")
+	pk := []byte{143, 218, 164, 37, 33, 79, 171, 35, 173, 65, 172, 42, 108, 25, 178, 74, 110, 127, 10, 67, 124, 101, 104, 2, 67, 196, 60, 34, 21, 251, 26, 229, 129, 213, 53, 107, 156, 63, 232, 139, 18, 72, 106, 77, 164, 252, 24, 120, 7, 142, 82, 63, 151, 100, 234, 175, 108, 8, 96, 246, 137, 54, 112, 73, 221, 195, 167, 110, 87, 162, 92, 134, 27, 96, 220, 244, 61, 171, 128, 13, 50, 68, 214, 205, 163, 99, 161, 118, 103, 10, 223, 213, 115, 224, 187, 193}
+
+	address, err := builder.GetAddressFromPublicKey(pk)
+	require.NoError(t, err)
+	require.Equal(t, xc.Address("rZ92eN72ju1usfFhbr3bbu1MuNyRJWPne71pW9A6BZbjLpVr6P9eURoof3qMdkn3FnzYv7EA1kjef5HCVdJ5yhpbF5DwkFDBzDsD11DpBar8w8P4qWTRP9Xw72AFVnugFUt"), address)
+}
+
+func TestGetPublicKeyFromAddress(t *testing.T) {
+	skBytes, err := hex.DecodeString("1d25811b76f43c86d59d757622773b2969ee71270ea810a42deda024e0cf896a")
+	require.NoError(t, err)
+
+	var blsKey bls.PrivateKey[bls.G2]
+	blsKey.UnmarshalBinary(skBytes)
+	pk := blsKey.PublicKey()
+	pkBytes, err := pk.MarshalBinary()
+
+	addr := xc.Address("rZ92eN72ju1usfFhbr3bbu1MuNyRJWPne71pW9A6BZbjLpVr6P9eURoof3qMdkn3FnzYv7EA1kjef5HCVdJ5yhpbF5DwkFDBzDsD11DpBar8w8P4qWTRP9Xw72AFVnugFUt")
+	addrPk, err := address.GetPublicKeyFromAddress(addr)
+	require.NoError(t, err)
+
+	addrPkBytes, err := addrPk.MarshalBinary()
+
+	// Raw `bls.PublicKey` can differ, we have to compare raw bytes
+	require.Equal(t, pkBytes, addrPkBytes)
 }

--- a/chain/dusk/builder/builder.go
+++ b/chain/dusk/builder/builder.go
@@ -1,0 +1,48 @@
+package builder
+
+import (
+	"errors"
+	"fmt"
+
+	xc "github.com/cordialsys/crosschain"
+	xcbuilder "github.com/cordialsys/crosschain/builder"
+	tx "github.com/cordialsys/crosschain/chain/dusk/tx"
+	duskinput "github.com/cordialsys/crosschain/chain/dusk/tx_input"
+)
+
+// TxBuilder for Template
+type TxBuilder struct {
+	Asset *xc.ChainBaseConfig
+}
+
+type TxInput = duskinput.TxInput
+
+var _ xcbuilder.FullTransferBuilder = TxBuilder{}
+
+// NewTxBuilder creates a new Template TxBuilder
+func NewTxBuilder(cfgI *xc.ChainBaseConfig) (TxBuilder, error) {
+	return TxBuilder{
+		Asset: cfgI,
+	}, nil
+}
+
+// NewTransfer creates a new transfer for an Asset, either native or token
+func (txBuilder TxBuilder) Transfer(args xcbuilder.TransferArgs, input xc.TxInput) (xc.Tx, error) {
+	txInput, ok := input.(*TxInput)
+	if !ok {
+		return nil, fmt.Errorf("invalid input type")
+	}
+
+	tx, err := tx.NewTx(args, *txInput)
+	return &tx, err
+}
+
+// NewNativeTransfer creates a new transfer for a native asset
+func (txBuilder TxBuilder) NewNativeTransfer(args xcbuilder.TransferArgs, input xc.TxInput) (xc.Tx, error) {
+	return nil, errors.New("not implemented")
+}
+
+// NewTokenTransfer creates a new transfer for a token asset
+func (txBuilder TxBuilder) NewTokenTransfer(args xcbuilder.TransferArgs, contract xc.ContractAddress, input xc.TxInput) (xc.Tx, error) {
+	return nil, fmt.Errorf("token transfers are not supported for %s", txBuilder.Asset.Chain)
+}

--- a/chain/dusk/builder/builder.go
+++ b/chain/dusk/builder/builder.go
@@ -1,7 +1,6 @@
 package builder
 
 import (
-	"errors"
 	"fmt"
 
 	xc "github.com/cordialsys/crosschain"
@@ -35,14 +34,4 @@ func (txBuilder TxBuilder) Transfer(args xcbuilder.TransferArgs, input xc.TxInpu
 
 	tx, err := tx.NewTx(args, *txInput)
 	return &tx, err
-}
-
-// NewNativeTransfer creates a new transfer for a native asset
-func (txBuilder TxBuilder) NewNativeTransfer(args xcbuilder.TransferArgs, input xc.TxInput) (xc.Tx, error) {
-	return nil, errors.New("not implemented")
-}
-
-// NewTokenTransfer creates a new transfer for a token asset
-func (txBuilder TxBuilder) NewTokenTransfer(args xcbuilder.TransferArgs, contract xc.ContractAddress, input xc.TxInput) (xc.Tx, error) {
-	return nil, fmt.Errorf("token transfers are not supported for %s", txBuilder.Asset.Chain)
 }

--- a/chain/dusk/builder/builder_test.go
+++ b/chain/dusk/builder/builder_test.go
@@ -1,0 +1,46 @@
+package builder_test
+
+import (
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/builder/buildertest"
+	"github.com/cordialsys/crosschain/chain/template/builder"
+	"github.com/cordialsys/crosschain/chain/template/tx_input"
+	"github.com/stretchr/testify/require"
+)
+
+type TxInput = tx_input.TxInput
+
+func TestNewTxBuilder(t *testing.T) {
+	builder1, err := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
+	require.NotNil(t, builder1)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestNewNativeTransfer(t *testing.T) {
+	builder, _ := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
+	from := xc.Address("from")
+	to := xc.Address("to")
+	amount := xc.AmountBlockchain{}
+	input := &TxInput{}
+	args := buildertest.MustNewTransferArgs(
+		from, to, amount,
+	)
+	_, err := builder.Transfer(args, input)
+	require.ErrorContains(t, err, "not implemented")
+}
+
+func TestNewTokenTransfer(t *testing.T) {
+	builder1, _ := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
+	from := xc.Address("from")
+	to := xc.Address("to")
+	amount := xc.AmountBlockchain{}
+	input := &TxInput{}
+	args := buildertest.MustNewTransferArgs(
+		from, to, amount,
+		buildertest.OptionContractAddress(xc.ContractAddress("contract")),
+	)
+	_, err := builder1.Transfer(args, input)
+	require.ErrorContains(t, err, "token transfers are not supported for XYZ")
+}

--- a/chain/dusk/builder/builder_test.go
+++ b/chain/dusk/builder/builder_test.go
@@ -5,42 +5,33 @@ import (
 
 	xc "github.com/cordialsys/crosschain"
 	"github.com/cordialsys/crosschain/builder/buildertest"
-	"github.com/cordialsys/crosschain/chain/template/builder"
-	"github.com/cordialsys/crosschain/chain/template/tx_input"
+	"github.com/cordialsys/crosschain/chain/dusk/builder"
+	"github.com/cordialsys/crosschain/chain/dusk/tx_input"
 	"github.com/stretchr/testify/require"
 )
 
 type TxInput = tx_input.TxInput
 
 func TestNewTxBuilder(t *testing.T) {
-	builder1, err := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
+	builder1, err := builder.NewTxBuilder(xc.NewChainConfig(xc.DUSK).Base())
 	require.NotNil(t, builder1)
-	require.EqualError(t, err, "not implemented")
+	require.NoError(t, err)
 }
 
-func TestNewNativeTransfer(t *testing.T) {
-	builder, _ := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
-	from := xc.Address("from")
-	to := xc.Address("to")
-	amount := xc.AmountBlockchain{}
-	input := &TxInput{}
-	args := buildertest.MustNewTransferArgs(
-		from, to, amount,
-	)
-	_, err := builder.Transfer(args, input)
-	require.ErrorContains(t, err, "not implemented")
-}
+func TestNewTransfer(t *testing.T) {
+	builder, _ := builder.NewTxBuilder(xc.NewChainConfig(xc.DUSK).Base())
+	from := xc.Address("2293LeWtYGpsBA99HRg2AfMm9oYhikZ83GSW5NP6QtQxDvkBTAdU8LfQj9fXvDt1rK1baqBcf3gQKsLXpw3LUjpdkSMRMrTsfuTo5Yri1xvUDnVcMMpgTG4o7ThCjZuLMp9L")
+	to := xc.Address("26nbWp93it1FF8ChyBUmV2zrXMqsv6xR41UUfcyq37abhoYvvEW4C8MgJPdKnzfQhfa6t1VtVj2QUeDK1aP98TGGtumV897Gtv3M7mh2qZBNK6C4LqvP6GyTeHvC7kPncVvg")
+	amount := xc.NewAmountBlockchainFromStr("1")
 
-func TestNewTokenTransfer(t *testing.T) {
-	builder1, _ := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
-	from := xc.Address("from")
-	to := xc.Address("to")
-	amount := xc.AmountBlockchain{}
-	input := &TxInput{}
-	args := buildertest.MustNewTransferArgs(
-		from, to, amount,
-		buildertest.OptionContractAddress(xc.ContractAddress("contract")),
-	)
-	_, err := builder1.Transfer(args, input)
-	require.ErrorContains(t, err, "token transfers are not supported for XYZ")
+	input := &TxInput{
+		Nonce:    1,
+		GasLimit: 250000,
+		GasPrice: 1,
+		ChainId:  1,
+	}
+
+	tf, err := builder.Transfer(buildertest.MustNewTransferArgs(from, to, amount), input)
+	require.NoError(t, err)
+	require.NotNil(t, tf)
 }

--- a/chain/dusk/client/client.go
+++ b/chain/dusk/client/client.go
@@ -152,7 +152,7 @@ func (client *Client) FetchTxInfo(ctx context.Context, txHash xc.TxHash) (xclien
 	params := types.GetTransactionParams{
 		Id: string(txHash),
 	}
-	request := types.NewGraphQlRequest(params.ToBytesParams(), "5d20d802b7a574c3316a103c02bb58b7")
+	request := types.NewGraphQlRequest(params.ToBytesParams())
 	var response types.GetTransactionResult
 	err = Request(client, request, &response)
 	if err != nil {
@@ -201,6 +201,11 @@ func (client *Client) FetchTxInfo(ctx context.Context, txHash xc.TxHash) (xclien
 	txInfo.AddFee(sourceAddress, "", feePrice, nil)
 	txInfo.Fees = txInfo.CalculateFees()
 	txInfo.Final = int(txInfo.Confirmations) > client.Asset.GetChain().ConfirmationsFinal
+	if response.SpentTransaction.Err != "" {
+		txInfo.Error = &response.SpentTransaction.Err
+	} else {
+		txInfo.Error = nil
+	}
 
 	return *txInfo, nil
 }
@@ -239,7 +244,7 @@ func (client *Client) FetchDecimals(ctx context.Context, contract xc.ContractAdd
 
 func (client *Client) FetchLatestBlockHeight() (uint64, error) {
 	params := &types.GetLastBlockParams{}
-	request := types.NewGraphQlRequest(params.ToBytesParams(), "5d20d802b7a574c3316a103c02bb58b7")
+	request := types.NewGraphQlRequest(params.ToBytesParams())
 	var response types.LastBlockPairResult
 	err := Request(client, request, &response)
 	if err != nil {
@@ -269,7 +274,7 @@ func (client *Client) FetchBlock(ctx context.Context, args *xclient.BlockArgs) (
 	params := &types.GetBlockParams{
 		Height: height,
 	}
-	request := types.NewGraphQlRequest(params.ToBytesParams(), "5d20d802b7a574c3316a103c02bb58b7")
+	request := types.NewGraphQlRequest(params.ToBytesParams())
 	var response types.GetBlockResult
 	err := Request(client, request, &response)
 	if err != nil {

--- a/chain/dusk/client/client.go
+++ b/chain/dusk/client/client.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 	types "github.com/cordialsys/crosschain/chain/dusk/client/types"
 	"github.com/cordialsys/crosschain/chain/dusk/tx_input"
 	xclient "github.com/cordialsys/crosschain/client"
+	"github.com/cordialsys/crosschain/client/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/stellar/go/support/time"
 )
@@ -124,6 +124,9 @@ func (client *Client) SubmitTx(ctx context.Context, tx xc.Tx) error {
 	var propagateResponse string
 	err = Request(client, propagateRequest, &propagateResponse)
 	if err != nil {
+		if strings.Contains(err.Error(), "this transaction exists in the mempool") {
+			return errors.TransactionExistsf("%v", err)
+		}
 		return fmt.Errorf("failed to submit tx: %w", err)
 	}
 
@@ -132,7 +135,7 @@ func (client *Client) SubmitTx(ctx context.Context, tx xc.Tx) error {
 
 // Returns transaction info - legacy/old endpoint
 func (client *Client) FetchLegacyTxInfo(ctx context.Context, txHash xc.TxHash) (xc.LegacyTxInfo, error) {
-	return xc.LegacyTxInfo{}, errors.New("not implemented")
+	return xc.LegacyTxInfo{}, fmt.Errorf("not implemented")
 }
 
 // Returns transaction info - new endpoint

--- a/chain/dusk/client/client.go
+++ b/chain/dusk/client/client.go
@@ -110,6 +110,9 @@ func (client *Client) SubmitTx(ctx context.Context, tx xc.Tx) error {
 	var verifyResponse string
 	err = Request(client, verifyRequest, &verifyResponse)
 	if err != nil {
+		if strings.Contains(err.Error(), "this transaction exists in the mempool") {
+			return errors.TransactionExistsf("%v", err)
+		}
 		return fmt.Errorf("failed to submit tx: %w", err)
 	}
 	if verifyResponse != "" {
@@ -129,7 +132,7 @@ func (client *Client) SubmitTx(ctx context.Context, tx xc.Tx) error {
 		if strings.Contains(err.Error(), "this transaction exists in the mempool") {
 			return errors.TransactionExistsf("%v", err)
 		}
-		return fmt.Errorf("failed to submit tx: %w", err)
+		return fmt.Errorf("failed to propagate tx: %w", err)
 	}
 
 	return nil

--- a/chain/dusk/client/client.go
+++ b/chain/dusk/client/client.go
@@ -77,11 +77,10 @@ func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.Tra
 	gasLimit := tx_input.EstimateFeeLimit(maxFee, gasPrice)
 
 	return &tx_input.TxInput{
-		Nonce:         accountStatus.Nonce + 1,
-		GasLimit:      gasLimit.Uint64(),
-		GasPrice:      gasPrice.Uint64(),
-		RefundAccount: args.GetFrom(),
-		ChainId:       chainId[0],
+		Nonce:    accountStatus.Nonce + 1,
+		GasLimit: gasLimit.Uint64(),
+		GasPrice: gasPrice.Uint64(),
+		ChainId:  chainId[0],
 	}, nil
 }
 

--- a/chain/dusk/client/client.go
+++ b/chain/dusk/client/client.go
@@ -1,0 +1,320 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	xc "github.com/cordialsys/crosschain"
+	xcbuilder "github.com/cordialsys/crosschain/builder"
+	types "github.com/cordialsys/crosschain/chain/dusk/client/types"
+	"github.com/cordialsys/crosschain/chain/dusk/tx_input"
+	xclient "github.com/cordialsys/crosschain/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/stellar/go/support/time"
+)
+
+// Client for Dusk
+type Client struct {
+	Asset      xc.ITask
+	Url        string
+	RuesUrl    string
+	HttpClient *http.Client
+	Logger     *log.Entry
+}
+
+var _ xclient.Client = &Client{}
+
+// NewClient returns a new Dusk Client
+func NewClient(cfgI xc.ITask) (*Client, error) {
+	cfg := cfgI.GetChain()
+	logger := log.WithFields(log.Fields{
+		"chain":   cfg.Chain,
+		"rpc":     cfg.URL,
+		"network": cfg.Network,
+	})
+
+	return &Client{
+		Asset:      cfgI,
+		Url:        cfg.GetChain().URL,
+		RuesUrl:    fmt.Sprintf("%s/on", cfg.GetChain().URL),
+		HttpClient: http.DefaultClient,
+		Logger:     logger,
+	}, nil
+}
+
+// FetchTransferInput returns tx input for a Dusk tx
+func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.TransferArgs) (xc.TxInput, error) {
+	accountStatus, err := client.FetchAccountStatus(args.GetFrom())
+	if err != nil {
+		return nil, err
+	}
+
+	// Calculate default fee_limit
+	maxFee := client.Asset.GetChain().FeeLimit.ToBlockchain(client.Asset.GetDecimals())
+	gasPrice := xc.NewAmountBlockchainFromUint64(tx_input.DEFAULT_GAS_PRICE)
+	gasLimit := tx_input.EstimateFeeLimit(maxFee, gasPrice)
+
+	return &tx_input.TxInput{
+		Nonce:         accountStatus.Nonce + 1,
+		GasLimit:      gasLimit.Uint64(),
+		GasPrice:      gasPrice.Uint64(),
+		RefundAccount: args.GetFrom(),
+	}, nil
+}
+
+// Deprecated method - use FetchTransferInput
+func (client *Client) FetchLegacyTxInput(ctx context.Context, from xc.Address, to xc.Address) (xc.TxInput, error) {
+	// No way to pass the amount in the input using legacy interface, so we estimate using min amount.
+	args, _ := xcbuilder.NewTransferArgs(from, to, xc.NewAmountBlockchainFromUint64(1))
+	return client.FetchTransferInput(ctx, args)
+}
+
+// SubmitTx verifies tx with `on/transactions/preverify` endpoint and then propagates it to the network
+// using `on/transactions/propagate` endpoint.
+func (client *Client) SubmitTx(ctx context.Context, tx xc.Tx) error {
+	bytes, err := tx.Serialize()
+	if err != nil {
+		return fmt.Errorf("failed to serialize tx: %w", err)
+	}
+
+	verifyRequest := types.RuesRequest{
+		Method: types.POST,
+		Target: types.TARGET_TRANSACTIONS,
+		Topic:  types.TOPIC_VERIFY,
+		Params: bytes,
+	}
+
+	var verifyResponse string
+	err = Request(client, verifyRequest, &verifyResponse)
+	if err != nil {
+		return fmt.Errorf("failed to submit tx: %w", err)
+	}
+	if verifyResponse != "" {
+		return fmt.Errorf("failed to verify tx: %s", verifyResponse)
+	}
+
+	propagateRequest := types.RuesRequest{
+		Method: types.POST,
+		Target: types.TARGET_TRANSACTIONS,
+		Topic:  types.TOPIC_PROPAGATE,
+		Params: bytes,
+	}
+
+	var propagateResponse string
+	err = Request(client, propagateRequest, &propagateResponse)
+	if err != nil {
+		return fmt.Errorf("failed to submit tx: %w", err)
+	}
+
+	return nil
+}
+
+// Returns transaction info - legacy/old endpoint
+func (client *Client) FetchLegacyTxInfo(ctx context.Context, txHash xc.TxHash) (xc.LegacyTxInfo, error) {
+	return xc.LegacyTxInfo{}, errors.New("not implemented")
+}
+
+// Returns transaction info - new endpoint
+func (client *Client) FetchTxInfo(ctx context.Context, txHash xc.TxHash) (xclient.TxInfo, error) {
+	latestHeight, err := client.FetchLatestBlockHeight()
+	if err != nil {
+		return xclient.TxInfo{}, err
+	}
+
+	params := types.GetTransactionParams{
+		Id: string(txHash),
+	}
+	request := types.NewGraphQlRequest(params.ToBytesParams(), "5d20d802b7a574c3316a103c02bb58b7")
+	var response types.GetTransactionResult
+	err = Request(client, request, &response)
+	if err != nil {
+		return xclient.TxInfo{}, err
+	}
+	if response.SpentTransaction == nil {
+		return xclient.TxInfo{}, fmt.Errorf("transaction not found: %s", txHash)
+	}
+
+	chain := client.Asset.GetChain().Chain
+	blockTime := time.MillisFromInt64(response.SpentTransaction.BlockTimestamp)
+	block := xclient.NewBlock(chain, response.SpentTransaction.BlockHeight, response.SpentTransaction.BlockHash, blockTime.ToTime())
+	txInfo := xclient.NewTxInfo(block, client.Asset.GetChain(), response.SpentTransaction.ID, latestHeight-block.Height.Uint64(), &response.SpentTransaction.Err)
+
+	transaction, err := response.SpentTransaction.Tx.GetTransaction()
+	if err != nil {
+		return xclient.TxInfo{}, fmt.Errorf("failed to get transaction: %w", err)
+	}
+	sourceAddress := xc.Address(transaction.Sender)
+	destinationAddress := xc.Address(transaction.Receiver)
+	amount := xc.NewAmountBlockchainFromUint64(transaction.Value)
+	movement := xclient.NewMovement(chain, "")
+	movement.AddSource(sourceAddress, amount, nil)
+	movement.AddDestination(destinationAddress, amount, nil)
+	txInfo.AddMovement(movement)
+
+	gasPrice := xc.NewAmountBlockchainFromStr(transaction.Fee.GasPrice)
+	gasUsed := xc.NewAmountBlockchainFromUint64(response.SpentTransaction.GasSpent)
+	feePrice := gasPrice.Mul(&gasUsed)
+	txInfo.AddFee(sourceAddress, "", feePrice, nil)
+	txInfo.Fees = txInfo.CalculateFees()
+	txInfo.Final = int(txInfo.Confirmations) > client.Asset.GetChain().ConfirmationsFinal
+
+	return *txInfo, nil
+}
+
+func (client *Client) FetchAccountStatus(address xc.Address) (types.GetAccountStatusResult, error) {
+	request := types.RuesRequest{
+		Method: types.POST,
+		Target: types.TARGET_ACCOUNT,
+		Entity: string(address),
+		Topic:  types.TOPIC_STATUS,
+		Params: nil,
+	}
+
+	var response types.GetAccountStatusResult
+	err := Request(client, request, &response)
+	if err != nil {
+		return types.GetAccountStatusResult{}, fmt.Errorf("failed to get account status: %w", err)
+	}
+
+	return response, nil
+}
+
+func (client *Client) FetchBalance(ctx context.Context, args *xclient.BalanceArgs) (xc.AmountBlockchain, error) {
+	accountStatus, err := client.FetchAccountStatus(args.Address())
+	if err != nil {
+		return xc.AmountBlockchain{}, err
+	}
+
+	amount := xc.NewAmountBlockchainFromUint64(accountStatus.Balance)
+	return amount, nil
+}
+
+func (client *Client) FetchDecimals(ctx context.Context, contract xc.ContractAddress) (int, error) {
+	return int(client.Asset.GetChain().GetDecimals()), nil
+}
+
+func (client *Client) FetchLatestBlockHeight() (uint64, error) {
+	params := &types.GetLastBlockParams{}
+	request := types.NewGraphQlRequest(params.ToBytesParams(), "5d20d802b7a574c3316a103c02bb58b7")
+	var response types.LastBlockPairResult
+	err := Request(client, request, &response)
+	if err != nil {
+		return 0, err
+	}
+
+	fh, ok := response.LastBlockPair.Json.LastFinalizedBlock[0].(float64)
+	if !ok {
+		return 0, fmt.Errorf("failed to get last finalized block height: %w", err)
+	}
+
+	return uint64(fh), nil
+}
+
+func (client *Client) FetchBlock(ctx context.Context, args *xclient.BlockArgs) (*xclient.BlockWithTransactions, error) {
+	height, ok := args.Height()
+	// Fetch latest finalized block height if `height` arg was not specified
+	if !ok {
+		h, err := client.FetchLatestBlockHeight()
+		if err != nil {
+			return nil, err
+		}
+
+		height = h
+	}
+
+	params := &types.GetBlockParams{
+		Height: height,
+	}
+	request := types.NewGraphQlRequest(params.ToBytesParams(), "5d20d802b7a574c3316a103c02bb58b7")
+	var response types.GetBlockResult
+	err := Request(client, request, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	block := response.Block
+	blockTimestamp := time.MillisFromInt64(block.Header.Timestamp)
+	xBlock := xclient.NewBlock(client.Asset.GetChain().Chain, block.Header.Height, block.Header.Hash, blockTimestamp.ToTime())
+	transactions := make([]string, 0, len(block.Transactions))
+	for _, tx := range block.Transactions {
+		transactions = append(transactions, tx.Id)
+	}
+
+	return &xclient.BlockWithTransactions{
+		Block:          *xBlock,
+		TransactionIds: transactions,
+	}, nil
+}
+
+// Send Rues request to the Dusk network
+func Request(client *Client, rr types.RuesRequest, resp interface{}) error {
+	logger := log.WithFields(log.Fields{
+		"target": rr.Target,
+		"entity": rr.Entity,
+		"topic":  rr.Topic,
+	})
+	url := rr.GetUrl(client.RuesUrl)
+
+	params := rr.GetParams()
+	request, err := http.NewRequest(rr.Method, url, bytes.NewBuffer(params))
+	logger.WithField("params", string(params)).Debug("sending request")
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	if rr.IsGraphQL() {
+		request.Header.Set("Content-Type", "application/json")
+	} else {
+		request.Header.Set("Content-Type", "application/octet-stream")
+	}
+
+	response, err := client.HttpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer response.Body.Close()
+
+	buff, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	// Trim `Rusk` node backtrace from the response body - it is noisy and not useful
+	stackBacktraceIdx := strings.Index(string(buff), "Stack backtrace")
+	if stackBacktraceIdx != -1 {
+		buff = buff[:stackBacktraceIdx]
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to send request, status: %s, error: %s", response.Status, buff)
+	}
+
+	logger.WithFields(log.Fields{
+		"responseBody": string(buff),
+		"status":       response.Status,
+		"code":         response.StatusCode,
+	}).Debug("got response")
+
+	if len(buff) == 0 {
+		return nil
+	}
+
+	switch resp.(type) {
+	case string:
+		resp = string(buff)
+	default:
+		err = json.Unmarshal(buff, resp)
+		if err != nil {
+			return fmt.Errorf("failed to decode response body: %w, buff: %s", err, string(buff))
+		}
+	}
+
+	return nil
+}

--- a/chain/dusk/client/client_test.go
+++ b/chain/dusk/client/client_test.go
@@ -2,42 +2,308 @@ package client_test
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	xc "github.com/cordialsys/crosschain"
-	"github.com/cordialsys/crosschain/chain/template/client"
-	"github.com/cordialsys/crosschain/chain/template/tx"
+	"github.com/cordialsys/crosschain/builder"
+	"github.com/cordialsys/crosschain/chain/dusk/client"
+	tx "github.com/cordialsys/crosschain/chain/dusk/tx"
+	"github.com/cordialsys/crosschain/chain/dusk/tx_input"
+	xclient "github.com/cordialsys/crosschain/client"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewClient(t *testing.T) {
+	url := "http://localhost:8080"
+	client, err := client.NewClient(&xc.ChainConfig{
+		ChainBaseConfig: &xc.ChainBaseConfig{},
+		ChainClientConfig: &xc.ChainClientConfig{
+			URL: url,
+		},
+	})
 
-	client, err := client.NewClient(xc.NewChainConfig(""))
 	require.NotNil(t, client)
-	require.EqualError(t, err, "not implemented")
+	require.NoError(t, err)
+	require.Equal(t, client.RuesUrl, fmt.Sprintf("%s/on", url))
 }
 
 func TestFetchTxInput(t *testing.T) {
+	vectors := []struct {
+		testName            string
+		accountStatusResult string
+		chainIdResult       string
+		feeLimit            xc.AmountHumanReadable
+		gasFeePriority      *xc.GasFeePriority
+		expected            tx_input.TxInput
+	}{
+		{
+			testName:            "TestInputNoGasPriority",
+			accountStatusResult: `{"balance":100,"nonce":20}`,
+			chainIdResult:       "\x01",
+			feeLimit:            xc.NewAmountHumanReadableFromFloat(2.0),
+			gasFeePriority:      nil,
+			expected: tx_input.TxInput{
+				// Incremented nonce by 1
+				Nonce: 21,
+				// Estimated basing on feeLimit
+				GasLimit: 2_000_000_000, // feeLimit / price
+				// Always 1 for now
+				GasPrice: 1,
+				ChainId:  1,
+			},
+		},
+		{
+			testName:            "LowGasPriority",
+			accountStatusResult: `{"balance":100,"nonce":20}`,
+			chainIdResult:       "\x01",
+			feeLimit:            xc.NewAmountHumanReadableFromFloat(2.0),
+			gasFeePriority:      &xc.Low,
+			expected: tx_input.TxInput{
+				// Incremented nonce by 1
+				Nonce: 21,
+				// Estimated basing on feeLimit
+				GasLimit: 1400000000, // (feeLimit / price) * 0.7
+				// Always 1 for now
+				GasPrice: 1,
+				ChainId:  1,
+			},
+		},
+		{
+			testName:            "CustomGasPriority",
+			accountStatusResult: `{"balance":100,"nonce":20}`,
+			chainIdResult:       "\x01",
+			feeLimit:            xc.NewAmountHumanReadableFromFloat(2.0),
+			gasFeePriority:      func() *xc.GasFeePriority { p, _ := xc.NewPriority("0.05"); return &p }(),
+			expected: tx_input.TxInput{
+				// Incremented nonce by 1
+				Nonce: 21,
+				// Estimated basing on feeLimit
+				GasLimit: 50_000_000, // (feeLimit / price) * 0.7
+				// Always 1 for now
+				GasPrice: 1,
+				ChainId:  1,
+			},
+		},
+	}
 
-	client, _ := client.NewClient(xc.NewChainConfig(""))
-	from := xc.Address("from")
-	to := xc.Address("to")
-	input, err := client.FetchLegacyTxInput(context.Background(), from, to)
-	require.NotNil(t, input)
-	require.EqualError(t, err, "not implemented")
+	for _, vector := range vectors {
+		t.Run(vector.testName, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				url := r.URL
+				if strings.Contains(url.Path, "account") {
+					w.Write([]byte(vector.accountStatusResult))
+				} else {
+					w.Write([]byte(vector.chainIdResult))
+				}
+			}))
+			defer server.Close()
+
+			config := xc.NewChainConfig(xc.DUSK).
+				WithUrl(server.URL).
+				WithFeeLimit(vector.feeLimit).
+				WithDecimals(9)
+
+			client, err := client.NewClient(config)
+			require.NoError(t, err)
+
+			input, err := client.FetchLegacyTxInput(context.Background(), xc.Address("from"), xc.Address("to"))
+			require.NoError(t, err)
+			if vector.gasFeePriority != nil {
+				input.SetGasFeePriority(*vector.gasFeePriority)
+			}
+			dusk_input := input.(*tx_input.TxInput)
+			require.Equal(t, vector.expected.Nonce, dusk_input.Nonce)
+			require.Equal(t, vector.expected.GasLimit, dusk_input.GasLimit)
+			require.Equal(t, vector.expected.GasPrice, dusk_input.GasPrice)
+			require.Equal(t, vector.expected.ChainId, dusk_input.ChainId)
+		})
+	}
 }
 
 func TestSubmitTx(t *testing.T) {
+	from := xc.Address("2293LeWtYGpsBA99HRg2AfMm9oYhikZ83GSW5NP6QtQxDvkBTAdU8LfQj9fXvDt1rK1baqBcf3gQKsLXpw3LUjpdkSMRMrTsfuTo5Yri1xvUDnVcMMpgTG4o7ThCjZuLMp9L")
+	to := xc.Address("26nbWp93it1FF8ChyBUmV2zrXMqsv6xR41UUfcyq37abhoYvvEW4C8MgJPdKnzfQhfa6t1VtVj2QUeDK1aP98TGGtumV897Gtv3M7mh2qZBNK6C4LqvP6GyTeHvC7kPncVvg")
+	args, err := builder.NewTransferArgs(
+		from,
+		to,
+		xc.NewAmountBlockchainFromUint64(5_000_000),
+	)
+	require.NoError(t, err)
+	exampleTx, err := tx.NewTx(args, tx_input.TxInput{
+		TxInputEnvelope: xc.TxInputEnvelope{},
+		Nonce:           10,
+		GasLimit:        2_500_000,
+		GasPrice:        1,
+		ChainId:         1,
+	})
+	require.NoError(t, err)
+	exampleTx.Signature = []byte{138, 52, 141, 88, 247, 205, 110, 26, 136, 4, 115, 92, 9, 180, 157, 74, 111, 167, 81, 176, 40, 192, 82, 165, 224, 187, 10, 48, 123, 54, 6, 103, 91, 40, 171, 11, 228, 111, 194, 56, 33, 140, 131, 4, 134, 17, 126, 228}
 
-	client, _ := client.NewClient(xc.NewChainConfig(""))
-	err := client.SubmitTx(context.Background(), &tx.Tx{})
-	require.EqualError(t, err, "not implemented")
+	vectors := []struct {
+		testName string
+		tx       *tx.Tx
+		err      string
+	}{
+		{
+			testName: "ValidTx",
+			tx:       &exampleTx,
+		},
+		{
+			testName: "ValidTx",
+			tx:       &exampleTx,
+			err:      "this transaction exists in the mempool",
+		},
+	}
+
+	for _, vector := range vectors {
+		t.Run(vector.testName, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if vector.err != "" {
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write([]byte(vector.err))
+				} else {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(""))
+				}
+			}))
+			defer server.Close()
+
+			config := xc.NewChainConfig(xc.DUSK).
+				WithUrl(server.URL).
+				WithFeeLimit(xc.NewAmountHumanReadableFromFloat(2.0)).
+				WithDecimals(9)
+
+			client, err := client.NewClient(config)
+			require.NoError(t, err)
+
+			err = client.SubmitTx(context.Background(), vector.tx)
+			if vector.err != "" {
+				require.ErrorContains(t, err, vector.err)
+				return
+			}
+		})
+	}
 }
 
 func TestFetchTxInfo(t *testing.T) {
+	vectors := []struct {
+		testName             string
+		lastBlockResult      string
+		getTransactionResult string
+		expectedInfo         xclient.TxInfo
+		err                  string
+	}{
+		{
+			testName:             "ValidTx",
+			lastBlockResult:      `{"lastBlockPair":{"json":{"last_block":[732552,"53a33b68a16a2d109ef6709c9f9a555b68005114d9ca5d2107df359c8cd70e43"],"last_finalized_block":[732551,"b929b84337f3c42552df162d015f2d93a4c5d6c8d439bb789e90a7c6525db139"]}}}`,
+			getTransactionResult: `{"tx":{"blockHash":"2c85f57c99b3b038b204a7119acb6356d97fc8c5dab0a5738bae0edb493867d4","blockHeight":723067,"blockTimestamp":1743489829,"err":null,"gasSpent":103396,"id":"98f64bce83ff51a179ca04ed5fa41d63b58b5d4044f575f12457d7151da4401d","tx":{"json":"{\"type\":\"moonlight\",\"sender\":\"zFVXTQZfY6gB2rWZFEm4ToWY2NKrpgeswTboWMAe7cjzaqHjsdGuADp8GsYzeruRkP3ZozA34mhWedEHkEiUr73iv8EcK3A192Y5b2uQYxLgprkZ2u8WKZyfDuZiyy4yEuL\",\"receiver\":\"23jFPiYSVEabmdo3zENKt4qSdBsVMDRTcneZ7LYKhfuB7E8UHXCLiPKDwXWTx4DAQirk2PhVkh6PiZKzaYhAkHuRwsKc7EAaB44yETLLzaWPoBGYDeoiwE82x9oY913RFUPH\",\"value\":1450000000000,\"nonce\":41,\"deposit\":0,\"fee\":{\"gas_limit\":\"100000000\",\"gas_price\":\"1\",\"refund_address\":\"zFVXTQZfY6gB2rWZFEm4ToWY2NKrpgeswTboWMAe7cjzaqHjsdGuADp8GsYzeruRkP3ZozA34mhWedEHkEiUr73iv8EcK3A192Y5b2uQYxLgprkZ2u8WKZyfDuZiyy4yEuL\"},\"call\":null,\"is_deploy\":false,\"memo\":null}"}}}`,
+			expectedInfo: xclient.TxInfo{
+				Name:   xclient.TransactionName("chains/DUSK/transactions/98f64bce83ff51a179ca04ed5fa41d63b58b5d4044f575f12457d7151da4401d"),
+				Hash:   "98f64bce83ff51a179ca04ed5fa41d63b58b5d4044f575f12457d7151da4401d",
+				XChain: xc.NativeAsset("DUSK"),
+				State:  xclient.Succeeded,
+				Final:  true,
+				Block: &xclient.Block{
+					Chain:  xc.NativeAsset("DUSK"),
+					Height: xc.NewAmountBlockchainFromUint64(723067),
+					Hash:   "2c85f57c99b3b038b204a7119acb6356d97fc8c5dab0a5738bae0edb493867d4",
+					Time:   MustParseTime("2025-04-01T08:43:49+02:00"),
+				},
+				Movements: []*xclient.Movement{
+					NewMovement(
+						"DUSK",
+						"DUSK",
+						[]*xclient.BalanceChange{
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(1450000000000),
+								XAddress:  "chains/DUSK/addresses/zFVXTQZfY6gB2rWZFEm4ToWY2NKrpgeswTboWMAe7cjzaqHjsdGuADp8GsYzeruRkP3ZozA34mhWedEHkEiUr73iv8EcK3A192Y5b2uQYxLgprkZ2u8WKZyfDuZiyy4yEuL",
+								AddressId: "zFVXTQZfY6gB2rWZFEm4ToWY2NKrpgeswTboWMAe7cjzaqHjsdGuADp8GsYzeruRkP3ZozA34mhWedEHkEiUr73iv8EcK3A192Y5b2uQYxLgprkZ2u8WKZyfDuZiyy4yEuL",
+							},
+						},
+						[]*xclient.BalanceChange{{
+							Balance:   xc.NewAmountBlockchainFromUint64(1450000000000),
+							XAddress:  "chains/DUSK/addresses/23jFPiYSVEabmdo3zENKt4qSdBsVMDRTcneZ7LYKhfuB7E8UHXCLiPKDwXWTx4DAQirk2PhVkh6PiZKzaYhAkHuRwsKc7EAaB44yETLLzaWPoBGYDeoiwE82x9oY913RFUPH",
+							AddressId: "23jFPiYSVEabmdo3zENKt4qSdBsVMDRTcneZ7LYKhfuB7E8UHXCLiPKDwXWTx4DAQirk2PhVkh6PiZKzaYhAkHuRwsKc7EAaB44yETLLzaWPoBGYDeoiwE82x9oY913RFUPH",
+						}},
+					),
+					NewMovement(
+						"DUSK",
+						"DUSK",
+						[]*xclient.BalanceChange{
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(103396),
+								XAddress:  "chains/DUSK/addresses/zFVXTQZfY6gB2rWZFEm4ToWY2NKrpgeswTboWMAe7cjzaqHjsdGuADp8GsYzeruRkP3ZozA34mhWedEHkEiUr73iv8EcK3A192Y5b2uQYxLgprkZ2u8WKZyfDuZiyy4yEuL",
+								AddressId: "zFVXTQZfY6gB2rWZFEm4ToWY2NKrpgeswTboWMAe7cjzaqHjsdGuADp8GsYzeruRkP3ZozA34mhWedEHkEiUr73iv8EcK3A192Y5b2uQYxLgprkZ2u8WKZyfDuZiyy4yEuL",
+							},
+						},
+						[]*xclient.BalanceChange{},
+					),
+				},
+				Fees: []*xclient.Balance{
+					{
+						Asset:    "chains/DUSK/assets/DUSK",
+						Contract: "DUSK",
+						Balance:  xc.NewAmountBlockchainFromUint64(103396),
+					},
+				},
+				Confirmations: 9484,
+				Error:         nil,
+			},
+		},
+	}
 
-	client, _ := client.NewClient(xc.NewChainConfig(""))
-	info, err := client.FetchLegacyTxInfo(context.Background(), xc.TxHash("hash"))
-	require.NotNil(t, info)
-	require.EqualError(t, err, "not implemented")
+	for _, vector := range vectors {
+		t.Run(vector.testName, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				reqBuff, _ := io.ReadAll(r.Body)
+				rawReq := string(reqBuff)
+				if strings.Contains(rawReq, "lastBlockPair") {
+					w.Write([]byte(vector.lastBlockResult))
+				} else {
+					w.Write([]byte(vector.getTransactionResult))
+				}
+			}))
+			defer server.Close()
+
+			config := xc.NewChainConfig(xc.DUSK, xc.DriverDusk).
+				WithUrl(server.URL).
+				WithFeeLimit(xc.NewAmountHumanReadableFromFloat(2.0)).
+				WithDecimals(9)
+
+			client, err := client.NewClient(config)
+			require.NoError(t, err)
+
+			txInfo, err := client.FetchTxInfo(context.Background(), xc.TxHash(vector.expectedInfo.Hash))
+			require.Equal(t, vector.expectedInfo, txInfo)
+		})
+	}
+}
+
+func NewMovement(
+	chain string,
+	contract string,
+	from []*xclient.BalanceChange,
+	to []*xclient.BalanceChange,
+) *xclient.Movement {
+	movement := xclient.NewMovement(xc.NativeAsset(chain), xc.ContractAddress(contract))
+	movement.From = from
+	movement.To = to
+
+	return movement
+}
+
+func MustParseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic("failed to parse time")
+	}
+
+	unixTime := t.Unix()
+	return time.Unix(unixTime, 0)
 }

--- a/chain/dusk/client/client_test.go
+++ b/chain/dusk/client/client_test.go
@@ -1,0 +1,43 @@
+package client_test
+
+import (
+	"context"
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/chain/template/client"
+	"github.com/cordialsys/crosschain/chain/template/tx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+
+	client, err := client.NewClient(xc.NewChainConfig(""))
+	require.NotNil(t, client)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestFetchTxInput(t *testing.T) {
+
+	client, _ := client.NewClient(xc.NewChainConfig(""))
+	from := xc.Address("from")
+	to := xc.Address("to")
+	input, err := client.FetchLegacyTxInput(context.Background(), from, to)
+	require.NotNil(t, input)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestSubmitTx(t *testing.T) {
+
+	client, _ := client.NewClient(xc.NewChainConfig(""))
+	err := client.SubmitTx(context.Background(), &tx.Tx{})
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestFetchTxInfo(t *testing.T) {
+
+	client, _ := client.NewClient(xc.NewChainConfig(""))
+	info, err := client.FetchLegacyTxInfo(context.Background(), xc.TxHash("hash"))
+	require.NotNil(t, info)
+	require.EqualError(t, err, "not implemented")
+}

--- a/chain/dusk/client/types/rues.go
+++ b/chain/dusk/client/types/rues.go
@@ -132,6 +132,8 @@ type Transaction struct {
 	Receiver string `json:"receiver"`
 	Value    uint64 `json:"value"`
 	Fee      Fee    `json:"fee"`
+	// This is hex encoded (encodes ascii potentially)
+	Memo string `json:"memo"`
 }
 
 type TransactionJson struct {

--- a/chain/dusk/client/types/rues.go
+++ b/chain/dusk/client/types/rues.go
@@ -1,0 +1,159 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	POST                = "POST"
+	TARGET_CONTRACT     = "contracts"
+	TARGET_ACCOUNT      = "account"
+	TARGET_GRAPHQL      = "graphql"
+	TARGET_TRANSACTIONS = "transactions"
+	TOPIC_STATUS        = "status"
+	TOPIC_QUERY         = "query"
+	TOPIC_PROPAGATE     = "propagate"
+	TOPIC_VERIFY        = "preverify"
+	TRANSFER_CONTRACT   = "0100000000000000000000000000000000000000000000000000000000000000"
+)
+
+// RuesRequest describes a request to the Dusk network.
+// Params representation varies:
+// - For GraphQL requests, it is a query string of standard GraphQL request
+// - Other endpoints can use custom formats, please refer to documentation or rusk-wallet source code
+//
+// https://docs.dusk.network/developer/integrations/rues
+type RuesRequest struct {
+	Method string
+	Target string
+	Entity string
+	Topic  string
+	Params []byte
+}
+
+func NewGraphQlRequest(params []byte, ruskSessionId string) RuesRequest {
+	return RuesRequest{
+		Method: POST,
+		Target: TARGET_GRAPHQL,
+		Entity: "",
+		Topic:  TOPIC_QUERY,
+		Params: params,
+	}
+}
+
+func (rr *RuesRequest) IsGraphQL() bool {
+	return rr.Target == TARGET_GRAPHQL
+}
+
+// URL schema: {rpc-url}/on/{target}:{entity}/{topic}
+// `:entity` part is optional and should be omitted if `entity` is empty
+func (rr *RuesRequest) GetUrl(base string) string {
+	if rr.Entity != "" {
+		return fmt.Sprintf("%s/%s:%s/%s", base, rr.Target, rr.Entity, rr.Topic)
+	} else {
+		return fmt.Sprintf("%s/%s/%s", base, rr.Target, rr.Topic)
+	}
+}
+
+func (rr *RuesRequest) GetParams() []byte {
+	return rr.Params
+}
+
+type GetAccountStatusResult struct {
+	// Account balance in blockchain amount
+	Balance uint64 `json:"balance"`
+	// Last transaction Nonce
+	Nonce uint64 `json:"nonce"`
+}
+
+type GetBlockParams struct {
+	Height uint64
+}
+
+func (rr *GetBlockParams) ToBytesParams() []byte {
+	return []byte(fmt.Sprintf(`query {block(height:%d) { header { hash, height, timestamp } , transactions {id}}}`, rr.Height))
+}
+
+type TransactionId struct {
+	Id string `json:"id"`
+}
+
+type BlockHeader struct {
+	Height    uint64 `json:"height"`
+	Hash      string `json:"hash"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+type Block struct {
+	Header       BlockHeader     `json:"header"`
+	Transactions []TransactionId `json:"transactions"`
+}
+
+type GetLastBlockParams struct{}
+
+func (rr *GetLastBlockParams) ToBytesParams() []byte {
+	return []byte("query {lastBlockPair { json }}")
+}
+
+type GetBlockResult struct {
+	Block Block `json:"block"`
+}
+
+type BlockPair struct {
+	// Array of `[height, hash]`
+	// Example: "last_finalized_block": [664,"transaction_hash"]
+	LastFinalizedBlock []interface{} `json:"last_finalized_block"`
+}
+
+type LastBlockPair struct {
+	Json BlockPair `json:"json"`
+}
+
+type LastBlockPairResult struct {
+	LastBlockPair LastBlockPair `json:"lastBlockPair"`
+}
+
+type GetTransactionParams struct {
+	Id string
+}
+
+func (rr *GetTransactionParams) ToBytesParams() []byte {
+	return []byte(fmt.Sprintf("query { tx(hash:\"%s\") { err, tx { json }, gasSpent, blockHash, blockHeight, blockTimestamp, id }}", rr.Id))
+}
+
+type Fee struct {
+	GasPrice string `json:"gas_price"`
+}
+
+type Transaction struct {
+	Sender   string `json:"sender"`
+	Receiver string `json:"receiver"`
+	Value    uint64 `json:"value"`
+	Fee      Fee    `json:"fee"`
+}
+
+type TransactionJson struct {
+	Json string `json:"json"`
+}
+
+func (t *TransactionJson) GetTransaction() (Transaction, error) {
+	var tx Transaction
+	err := json.Unmarshal([]byte(t.Json), &tx)
+	return tx, err
+}
+
+type SpentTransaction struct {
+	Tx             TransactionJson `json:"tx"`
+	Err            string          `json:"err,omitempty"`
+	GasSpent       uint64          `json:"gasSpent"`
+	BlockHash      string          `json:"blockHash"`
+	BlockHeight    uint64          `json:"blockHeight"`
+	BlockTimestamp int64           `json:"blockTimestamp"`
+	ID             string          `json:"id"`
+	Raw            string          `json:"raw"`
+}
+
+type GetTransactionResult struct {
+	SpentTransaction *SpentTransaction `json:"tx,omitempty"`
+}

--- a/chain/dusk/client/types/rues.go
+++ b/chain/dusk/client/types/rues.go
@@ -33,7 +33,7 @@ type RuesRequest struct {
 	Params []byte
 }
 
-func NewGraphQlRequest(params []byte, ruskSessionId string) RuesRequest {
+func NewGraphQlRequest(params []byte) RuesRequest {
 	return RuesRequest{
 		Method: POST,
 		Target: TARGET_GRAPHQL,

--- a/chain/dusk/client/types/rues.go
+++ b/chain/dusk/client/types/rues.go
@@ -11,6 +11,7 @@ const (
 	TARGET_ACCOUNT      = "account"
 	TARGET_GRAPHQL      = "graphql"
 	TARGET_TRANSACTIONS = "transactions"
+	TOPIC_CHAIN_ID      = "chain_id"
 	TOPIC_STATUS        = "status"
 	TOPIC_QUERY         = "query"
 	TOPIC_PROPAGATE     = "propagate"
@@ -156,4 +157,7 @@ type SpentTransaction struct {
 
 type GetTransactionResult struct {
 	SpentTransaction *SpentTransaction `json:"tx,omitempty"`
+}
+
+type GetChainIdParams struct {
 }

--- a/chain/dusk/dusk_bls.go
+++ b/chain/dusk/dusk_bls.go
@@ -1,0 +1,479 @@
+package dusk
+
+// This package contains utilities to that allows us to follow the signing process used in
+// dusk-bls library: https://github.com/dusk-network/bls12_381
+import (
+	"encoding/binary"
+	"fmt"
+	"math/bits"
+
+	"github.com/cloudflare/circl/ecc/bls12381"
+	"golang.org/x/crypto/blake2b"
+)
+
+var R2 = [4]uint64{
+	0xc999_e990_f3f2_9c6d,
+	0x2b6c_edcb_8792_5c23,
+	0x05d3_1496_7254_398f,
+	0x0748_d9d9_9f59_ff11,
+}
+
+var R3 = [4]uint64{
+	0xc62c_1807_439b_73af,
+	0x1b3e_0d18_8cf0_6990,
+	0x73d1_3c71_c7b5_f418,
+	0x6e2a_5bb9_c8db_33e9,
+}
+
+// Implements dusk-bls12_381 `hash_to_scalar` function.
+// See: https://github.com/dusk-network/bls12_381/blob/master/src/scalar/dusk.rs#L286
+func Blake2bScalarReduce(in []byte) (bls12381.Scalar, error) {
+	blake2b, err := blake2b.New(64, nil)
+	if err != nil {
+		return bls12381.Scalar{}, fmt.Errorf("failed to create blake2b hash: %w", err)
+	}
+
+	blake2b.Write(in)
+	bytes := blake2b.Sum(nil)
+	scalarMont1 := [4]uint64{
+		binary.LittleEndian.Uint64(bytes[0:8]),
+		binary.LittleEndian.Uint64(bytes[8:16]),
+		binary.LittleEndian.Uint64(bytes[16:24]),
+		binary.LittleEndian.Uint64(bytes[24:32]),
+	}
+	d1 := ScalarFromMont(scalarMont1)
+	r2 := ScalarFromMont(R2)
+	var p1 bls12381.Scalar
+	p1.Mul(&d1, &r2)
+
+	scalarMont2 := [4]uint64{
+		binary.LittleEndian.Uint64(bytes[32:40]),
+		binary.LittleEndian.Uint64(bytes[40:48]),
+		binary.LittleEndian.Uint64(bytes[48:56]),
+		binary.LittleEndian.Uint64(bytes[56:64]),
+	}
+	d2 := ScalarFromMont(scalarMont2)
+	r3 := ScalarFromMont(R3)
+	var p2 bls12381.Scalar
+	p2.Mul(&d2, &r3)
+
+	var result bls12381.Scalar
+	result.Add(&p1, &p2)
+
+	return result, nil
+}
+
+// Method `fromMont` from package `ff` in github.com/cloudflare/circl library
+// Convert scalar in mont representation to big-endian int representation
+func ScalarFromMont(in [4]uint64) bls12381.Scalar {
+	var out [4]uint64
+	fiatScMontMul(&out, &in, &[4]uint64{1})
+	bytesBe := Uint64Le2BytesBe(out[:])
+	var scalar bls12381.Scalar
+	scalar.SetBytes(bytesBe)
+	return scalar
+}
+
+// ScalarToLeBytes converts a bls12381.Scalar to a little-endian byte slice.
+func ScalarToLeBytes(scalar bls12381.Scalar) ([]byte, error) {
+	// MarshalBinary converts scalar to montgomery domain and marshals
+	// it in a big-endian order.
+	bytes, err := scalar.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal scalar: %w", err)
+	}
+
+	if len(bytes)%8 != 0 {
+		return nil, fmt.Errorf("scalar length is not a multiple of 8")
+	}
+
+	// Convert bytes to little-endian order
+	leBytes := make([]byte, 0)
+	for i := len(bytes); i > 0; i -= 8 {
+		u64 := binary.BigEndian.Uint64(bytes[i-8 : i])
+		leBytes = binary.LittleEndian.AppendUint64(leBytes, u64)
+	}
+	return leBytes, nil
+}
+
+// This funcion is copied from github.com/cloudflare/circl library.
+// For more details browse: https://github.com/cloudflare/circl/blob/main/ecc/bls12381/ff/scalar.go
+func fiatScMontMul(out1 *[4]uint64, arg1 *[4]uint64, arg2 *[4]uint64) {
+	x1 := arg1[1]
+	x2 := arg1[2]
+	x3 := arg1[3]
+	x4 := arg1[0]
+	var x5 uint64
+	var x6 uint64
+	x6, x5 = bits.Mul64(x4, arg2[3])
+	var x7 uint64
+	var x8 uint64
+	x8, x7 = bits.Mul64(x4, arg2[2])
+	var x9 uint64
+	var x10 uint64
+	x10, x9 = bits.Mul64(x4, arg2[1])
+	var x11 uint64
+	var x12 uint64
+	x12, x11 = bits.Mul64(x4, arg2[0])
+	var x13 uint64
+	var x14 uint64
+	x13, x14 = bits.Add64(x12, x9, uint64(0x0))
+	var x15 uint64
+	var x16 uint64
+	x15, x16 = bits.Add64(x10, x7, uint64(x14))
+	var x17 uint64
+	var x18 uint64
+	x17, x18 = bits.Add64(x8, x5, uint64(x16))
+	x19 := (x18 + x6)
+	var x20 uint64
+	_, x20 = bits.Mul64(x11, 0xfffffffeffffffff)
+	var x22 uint64
+	var x23 uint64
+	x23, x22 = bits.Mul64(x20, 0x73eda753299d7d48)
+	var x24 uint64
+	var x25 uint64
+	x25, x24 = bits.Mul64(x20, 0x3339d80809a1d805)
+	var x26 uint64
+	var x27 uint64
+	x27, x26 = bits.Mul64(x20, 0x53bda402fffe5bfe)
+	var x28 uint64
+	var x29 uint64
+	x29, x28 = bits.Mul64(x20, 0xffffffff00000001)
+	var x30 uint64
+	var x31 uint64
+	x30, x31 = bits.Add64(x29, x26, uint64(0x0))
+	var x32 uint64
+	var x33 uint64
+	x32, x33 = bits.Add64(x27, x24, uint64(x31))
+	var x34 uint64
+	var x35 uint64
+	x34, x35 = bits.Add64(x25, x22, uint64(x33))
+	x36 := (x35 + x23)
+	var x38 uint64
+	_, x38 = bits.Add64(x11, x28, uint64(0x0))
+	var x39 uint64
+	var x40 uint64
+	x39, x40 = bits.Add64(x13, x30, uint64(x38))
+	var x41 uint64
+	var x42 uint64
+	x41, x42 = bits.Add64(x15, x32, uint64(x40))
+	var x43 uint64
+	var x44 uint64
+	x43, x44 = bits.Add64(x17, x34, uint64(x42))
+	var x45 uint64
+	var x46 uint64
+	x45, x46 = bits.Add64(x19, x36, uint64(x44))
+	var x47 uint64
+	var x48 uint64
+	x48, x47 = bits.Mul64(x1, arg2[3])
+	var x49 uint64
+	var x50 uint64
+	x50, x49 = bits.Mul64(x1, arg2[2])
+	var x51 uint64
+	var x52 uint64
+	x52, x51 = bits.Mul64(x1, arg2[1])
+	var x53 uint64
+	var x54 uint64
+	x54, x53 = bits.Mul64(x1, arg2[0])
+	var x55 uint64
+	var x56 uint64
+	x55, x56 = bits.Add64(x54, x51, uint64(0x0))
+	var x57 uint64
+	var x58 uint64
+	x57, x58 = bits.Add64(x52, x49, uint64(x56))
+	var x59 uint64
+	var x60 uint64
+	x59, x60 = bits.Add64(x50, x47, uint64(x58))
+	x61 := (x60 + x48)
+	var x62 uint64
+	var x63 uint64
+	x62, x63 = bits.Add64(x39, x53, uint64(0x0))
+	var x64 uint64
+	var x65 uint64
+	x64, x65 = bits.Add64(x41, x55, uint64(x63))
+	var x66 uint64
+	var x67 uint64
+	x66, x67 = bits.Add64(x43, x57, uint64(x65))
+	var x68 uint64
+	var x69 uint64
+	x68, x69 = bits.Add64(x45, x59, uint64(x67))
+	var x70 uint64
+	var x71 uint64
+	x70, x71 = bits.Add64(x46, x61, uint64(x69))
+	var x72 uint64
+	_, x72 = bits.Mul64(x62, 0xfffffffeffffffff)
+	var x74 uint64
+	var x75 uint64
+	x75, x74 = bits.Mul64(x72, 0x73eda753299d7d48)
+	var x76 uint64
+	var x77 uint64
+	x77, x76 = bits.Mul64(x72, 0x3339d80809a1d805)
+	var x78 uint64
+	var x79 uint64
+	x79, x78 = bits.Mul64(x72, 0x53bda402fffe5bfe)
+	var x80 uint64
+	var x81 uint64
+	x81, x80 = bits.Mul64(x72, 0xffffffff00000001)
+	var x82 uint64
+	var x83 uint64
+	x82, x83 = bits.Add64(x81, x78, uint64(0x0))
+	var x84 uint64
+	var x85 uint64
+	x84, x85 = bits.Add64(x79, x76, uint64(x83))
+	var x86 uint64
+	var x87 uint64
+	x86, x87 = bits.Add64(x77, x74, uint64(x85))
+	x88 := (x87 + x75)
+	var x90 uint64
+	_, x90 = bits.Add64(x62, x80, uint64(0x0))
+	var x91 uint64
+	var x92 uint64
+	x91, x92 = bits.Add64(x64, x82, uint64(x90))
+	var x93 uint64
+	var x94 uint64
+	x93, x94 = bits.Add64(x66, x84, uint64(x92))
+	var x95 uint64
+	var x96 uint64
+	x95, x96 = bits.Add64(x68, x86, uint64(x94))
+	var x97 uint64
+	var x98 uint64
+	x97, x98 = bits.Add64(x70, x88, uint64(x96))
+	x99 := (x98 + x71)
+	var x100 uint64
+	var x101 uint64
+	x101, x100 = bits.Mul64(x2, arg2[3])
+	var x102 uint64
+	var x103 uint64
+	x103, x102 = bits.Mul64(x2, arg2[2])
+	var x104 uint64
+	var x105 uint64
+	x105, x104 = bits.Mul64(x2, arg2[1])
+	var x106 uint64
+	var x107 uint64
+	x107, x106 = bits.Mul64(x2, arg2[0])
+	var x108 uint64
+	var x109 uint64
+	x108, x109 = bits.Add64(x107, x104, uint64(0x0))
+	var x110 uint64
+	var x111 uint64
+	x110, x111 = bits.Add64(x105, x102, uint64(x109))
+	var x112 uint64
+	var x113 uint64
+	x112, x113 = bits.Add64(x103, x100, uint64(x111))
+	x114 := (x113 + x101)
+	var x115 uint64
+	var x116 uint64
+	x115, x116 = bits.Add64(x91, x106, uint64(0x0))
+	var x117 uint64
+	var x118 uint64
+	x117, x118 = bits.Add64(x93, x108, uint64(x116))
+	var x119 uint64
+	var x120 uint64
+	x119, x120 = bits.Add64(x95, x110, uint64(x118))
+	var x121 uint64
+	var x122 uint64
+	x121, x122 = bits.Add64(x97, x112, uint64(x120))
+	var x123 uint64
+	var x124 uint64
+	x123, x124 = bits.Add64(x99, x114, uint64(x122))
+	var x125 uint64
+	_, x125 = bits.Mul64(x115, 0xfffffffeffffffff)
+	var x127 uint64
+	var x128 uint64
+	x128, x127 = bits.Mul64(x125, 0x73eda753299d7d48)
+	var x129 uint64
+	var x130 uint64
+	x130, x129 = bits.Mul64(x125, 0x3339d80809a1d805)
+	var x131 uint64
+	var x132 uint64
+	x132, x131 = bits.Mul64(x125, 0x53bda402fffe5bfe)
+	var x133 uint64
+	var x134 uint64
+	x134, x133 = bits.Mul64(x125, 0xffffffff00000001)
+	var x135 uint64
+	var x136 uint64
+	x135, x136 = bits.Add64(x134, x131, uint64(0x0))
+	var x137 uint64
+	var x138 uint64
+	x137, x138 = bits.Add64(x132, x129, uint64(x136))
+	var x139 uint64
+	var x140 uint64
+	x139, x140 = bits.Add64(x130, x127, uint64(x138))
+	x141 := (x140 + x128)
+	var x143 uint64
+	_, x143 = bits.Add64(x115, x133, uint64(0x0))
+	var x144 uint64
+	var x145 uint64
+	x144, x145 = bits.Add64(x117, x135, uint64(x143))
+	var x146 uint64
+	var x147 uint64
+	x146, x147 = bits.Add64(x119, x137, uint64(x145))
+	var x148 uint64
+	var x149 uint64
+	x148, x149 = bits.Add64(x121, x139, uint64(x147))
+	var x150 uint64
+	var x151 uint64
+	x150, x151 = bits.Add64(x123, x141, uint64(x149))
+	x152 := (x151 + x124)
+	var x153 uint64
+	var x154 uint64
+	x154, x153 = bits.Mul64(x3, arg2[3])
+	var x155 uint64
+	var x156 uint64
+	x156, x155 = bits.Mul64(x3, arg2[2])
+	var x157 uint64
+	var x158 uint64
+	x158, x157 = bits.Mul64(x3, arg2[1])
+	var x159 uint64
+	var x160 uint64
+	x160, x159 = bits.Mul64(x3, arg2[0])
+	var x161 uint64
+	var x162 uint64
+	x161, x162 = bits.Add64(x160, x157, uint64(0x0))
+	var x163 uint64
+	var x164 uint64
+	x163, x164 = bits.Add64(x158, x155, uint64(x162))
+	var x165 uint64
+	var x166 uint64
+	x165, x166 = bits.Add64(x156, x153, uint64(x164))
+	x167 := (x166 + x154)
+	var x168 uint64
+	var x169 uint64
+	x168, x169 = bits.Add64(x144, x159, uint64(0x0))
+	var x170 uint64
+	var x171 uint64
+	x170, x171 = bits.Add64(x146, x161, uint64(x169))
+	var x172 uint64
+	var x173 uint64
+	x172, x173 = bits.Add64(x148, x163, uint64(x171))
+	var x174 uint64
+	var x175 uint64
+	x174, x175 = bits.Add64(x150, x165, uint64(x173))
+	var x176 uint64
+	var x177 uint64
+	x176, x177 = bits.Add64(x152, x167, uint64(x175))
+	var x178 uint64
+	_, x178 = bits.Mul64(x168, 0xfffffffeffffffff)
+	var x180 uint64
+	var x181 uint64
+	x181, x180 = bits.Mul64(x178, 0x73eda753299d7d48)
+	var x182 uint64
+	var x183 uint64
+	x183, x182 = bits.Mul64(x178, 0x3339d80809a1d805)
+	var x184 uint64
+	var x185 uint64
+	x185, x184 = bits.Mul64(x178, 0x53bda402fffe5bfe)
+	var x186 uint64
+	var x187 uint64
+	x187, x186 = bits.Mul64(x178, 0xffffffff00000001)
+	var x188 uint64
+	var x189 uint64
+	x188, x189 = bits.Add64(x187, x184, uint64(0x0))
+	var x190 uint64
+	var x191 uint64
+	x190, x191 = bits.Add64(x185, x182, uint64(x189))
+	var x192 uint64
+	var x193 uint64
+	x192, x193 = bits.Add64(x183, x180, uint64(x191))
+	x194 := (x193 + x181)
+	var x196 uint64
+	_, x196 = bits.Add64(x168, x186, uint64(0x0))
+	var x197 uint64
+	var x198 uint64
+	x197, x198 = bits.Add64(x170, x188, uint64(x196))
+	var x199 uint64
+	var x200 uint64
+	x199, x200 = bits.Add64(x172, x190, uint64(x198))
+	var x201 uint64
+	var x202 uint64
+	x201, x202 = bits.Add64(x174, x192, uint64(x200))
+	var x203 uint64
+	var x204 uint64
+	x203, x204 = bits.Add64(x176, x194, uint64(x202))
+	x205 := (x204 + x177)
+	var x206 uint64
+	var x207 uint64
+	x206, x207 = bits.Sub64(x197, 0xffffffff00000001, uint64(uint64(0x0)))
+	var x208 uint64
+	var x209 uint64
+	x208, x209 = bits.Sub64(x199, 0x53bda402fffe5bfe, uint64(x207))
+	var x210 uint64
+	var x211 uint64
+	x210, x211 = bits.Sub64(x201, 0x3339d80809a1d805, uint64(x209))
+	var x212 uint64
+	var x213 uint64
+	x212, x213 = bits.Sub64(x203, 0x73eda753299d7d48, uint64(x211))
+	var x215 uint64
+	_, x215 = bits.Sub64(x205, uint64(0x0), uint64(x213))
+	var x216 uint64
+	fiatScMontCmovznzU64(&x216, x215, x206, x197)
+	var x217 uint64
+	fiatScMontCmovznzU64(&x217, x215, x208, x199)
+	var x218 uint64
+	fiatScMontCmovznzU64(&x218, x215, x210, x201)
+	var x219 uint64
+	fiatScMontCmovznzU64(&x219, x215, x212, x203)
+	out1[0] = x216
+	out1[1] = x217
+	out1[2] = x218
+	out1[3] = x219
+}
+
+func fiatScMontCmovznzU64(z *uint64, b, x, y uint64) { cselectU64(z, b, x, y) }
+func cselectU64(z *uint64, b, x, y uint64)           { *z = (x &^ (-b)) | (y & (-b)) }
+
+// Uint64Le2BytesBe converts a little-endian slice x to a big-endian slice of bytes.
+func Uint64Le2BytesBe(x []uint64) []byte {
+	b := make([]byte, 8*len(x))
+	n := len(x)
+	for i := 0; i < n; i++ {
+		binary.BigEndian.PutUint64(b[i*8:], x[n-1-i])
+	}
+	return b
+}
+
+// This is a simple double-and-add implementation of point
+// multiplication, moving from most significant to least
+// significant bit of the scalar.
+//
+// We skip the leading bit because it's always unset for Fq
+// elements.
+func ScalarMultShorti(k []byte, P *bls12381.G1) *bls12381.G1 {
+	// Since the scalar is short and low Hamming weight not much helps.
+	var Q bls12381.G1
+	Q.SetIdentity()
+
+	for i := len(k) - 1; i >= 0; i-- {
+		byte := k[i]
+		for j := 7; j >= 0; j-- {
+			if i == len(k)-1 && j == 7 {
+				continue // Skip the leading bit
+			}
+			bit := (byte >> j) & 1
+
+			Q.Double()
+			if bit == 1 {
+				Q.Add(&Q, P)
+			}
+		}
+	}
+
+	return &Q
+}
+
+// scalarMultShort multiplies by a short, constant scalar k, where k is the
+// scalar in big-endian order. Runtime depends on the scalar.
+func ScalarMultShort(k []byte, P *bls12381.G1) *bls12381.G1 {
+	// Since the scalar is short and low Hamming weight not much helps.
+	var Q bls12381.G1
+	Q.SetIdentity()
+	N := 8 * len(k)
+	for i := 0; i < N; i++ {
+		Q.Double()
+		bit := 0x1 & (k[i/8] >> uint(7-i%8))
+		if bit != 0 {
+			Q.Add(&Q, P)
+		}
+	}
+	return &Q
+}

--- a/chain/dusk/errors.go
+++ b/chain/dusk/errors.go
@@ -1,0 +1,7 @@
+package dusk
+
+import "github.com/cordialsys/crosschain/client/errors"
+
+func CheckError(err error) errors.Status {
+	return ""
+}

--- a/chain/dusk/tx/tx.go
+++ b/chain/dusk/tx/tx.go
@@ -1,0 +1,264 @@
+package tx
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+
+	"github.com/cloudflare/circl/sign/bls"
+	xc "github.com/cordialsys/crosschain"
+	xcbuilder "github.com/cordialsys/crosschain/builder"
+	"github.com/cordialsys/crosschain/chain/dusk"
+	"github.com/cordialsys/crosschain/chain/dusk/address"
+	"github.com/cordialsys/crosschain/chain/dusk/tx_input"
+)
+
+// Tx for Dusk
+type Tx struct {
+	Payload   Payload
+	Signature []byte
+}
+
+type Fee struct {
+	GasLimit      uint64
+	GasPrice      uint64
+	RefundAddress bls.PublicKey[bls.G2]
+}
+
+type Payload struct {
+	// ID of the chain for this transaction to execute on.
+	ChainId uint8
+	// Key of the sender of this transaction.
+	Sender bls.PublicKey[bls.G2]
+	// Key of the receiver of the funds.
+	Receiver bls.PublicKey[bls.G2]
+	// Value to be transferred.
+	Value uint64
+	// Deposit for a contract.
+	Deposit uint64
+	// Data used to calculate the transaction fee and refund unspent gas.
+	Fee Fee
+	// Nonce used for replay protection. Moonlight nonces are strictly
+	// increasing and incremental, meaning that for a transaction to be
+	// valid, only the current nonce + 1 can be used.
+	//
+	// The current nonce is queryable via the transfer contract or account
+	// status.
+	Nonce uint64
+	Memo  []byte
+}
+
+func NewTx(args xcbuilder.TransferArgs, input tx_input.TxInput) (Tx, error) {
+	senderKey, err := address.GetPublicKeyFromAddress(args.GetFrom())
+	if err != nil {
+		return Tx{}, errors.New("failed to get public key from sender address")
+	}
+
+	receiverKey, err := address.GetPublicKeyFromAddress(args.GetTo())
+	if err != nil {
+		return Tx{}, errors.New("failed to get public key from receiver address")
+	}
+
+	refoundKey, err := address.GetPublicKeyFromAddress(input.RefundAccount)
+	if err != nil {
+		return Tx{}, errors.New("failed to get public key from refund address")
+	}
+
+	tx := Tx{
+		Payload: Payload{
+			ChainId:  1,
+			Sender:   senderKey,
+			Receiver: receiverKey,
+			Value:    args.GetAmount().Int().Uint64(),
+			Deposit:  0,
+			Fee: Fee{
+				GasLimit:      input.GasLimit,
+				GasPrice:      input.GasPrice,
+				RefundAddress: refoundKey,
+			},
+			Nonce: input.Nonce,
+			Memo:  []byte(input.Memo),
+		},
+	}
+
+	return tx, nil
+}
+
+var _ xc.Tx = &Tx{}
+
+// Hash returns the tx hash or id
+func (tx Tx) Hash() xc.TxHash {
+	sighashes, err := tx.Sighashes()
+	if err != nil {
+		return xc.TxHash("failed to get sighashes")
+	}
+	if len(sighashes) != 1 {
+		return xc.TxHash("expected only one sighash")
+	}
+
+	sighash := sighashes[0]
+	sighash = append(sighash, tx.Signature...)
+	scalar, err := dusk.Blake2bScalarReduce(sighash)
+	if err != nil {
+		return xc.TxHash("failed to get scalar from sighash")
+	}
+
+	bytes, err := dusk.ScalarToLeBytes(scalar)
+	if err != nil {
+		return xc.TxHash("failed to marshal scalar")
+	}
+
+	hash := hex.EncodeToString(bytes)
+	return xc.TxHash(hash)
+}
+
+func (tx Tx) SighashBase() ([]byte, error) {
+	bytes := make([]byte, 0)
+	bytes = append(bytes, tx.Payload.ChainId)
+
+	senderBytes, err := tx.Payload.Sender.MarshalBinary()
+	if err != nil {
+		return []byte{}, errors.New("failed to marshal sender")
+	}
+	bytes = append(bytes, senderBytes...)
+	if tx.Payload.Receiver != tx.Payload.Sender {
+		receiverBytes, err := tx.Payload.Receiver.MarshalBinary()
+		if err != nil {
+			return []byte{}, errors.New("failed to marshal receiver")
+		}
+		bytes = append(bytes, receiverBytes...)
+	}
+
+	bytes = binary.LittleEndian.AppendUint64(bytes, tx.Payload.Value)
+	bytes = binary.LittleEndian.AppendUint64(bytes, tx.Payload.Deposit)
+	bytes = binary.LittleEndian.AppendUint64(bytes, tx.Payload.Fee.GasLimit)
+	bytes = binary.LittleEndian.AppendUint64(bytes, tx.Payload.Fee.GasPrice)
+	if tx.Payload.Fee.RefundAddress != tx.Payload.Sender {
+		refundAddressBytes, err := tx.Payload.Fee.RefundAddress.MarshalBinary()
+		if err != nil {
+			return []byte{}, errors.New("failed to marshal refund address")
+		}
+		bytes = append(bytes, refundAddressBytes...)
+	}
+	bytes = binary.LittleEndian.AppendUint64(bytes, tx.Payload.Nonce)
+
+	if len(tx.Payload.Memo) > 0 {
+		bytes = append(bytes, tx.Payload.Memo...)
+	}
+
+	return bytes, nil
+
+}
+
+// Sighashes returns the tx payload to sign, aka sighash
+func (tx Tx) Sighashes() ([]xc.TxDataToSign, error) {
+	bytes := make([]byte, 0)
+	bytes = append(bytes, tx.Payload.ChainId)
+
+	senderBytes, err := tx.Payload.Sender.MarshalBinary()
+	if err != nil {
+		return []xc.TxDataToSign{}, errors.New("failed to marshal sender")
+	}
+	bytes = append(bytes, senderBytes...)
+	if tx.Payload.Receiver != tx.Payload.Sender {
+		receiverBytes, err := tx.Payload.Receiver.MarshalBinary()
+		if err != nil {
+			return []xc.TxDataToSign{}, errors.New("failed to marshal receiver")
+		}
+		bytes = append(bytes, receiverBytes...)
+	}
+
+	bytes = binary.LittleEndian.AppendUint64(bytes, tx.Payload.Value)
+	bytes = binary.LittleEndian.AppendUint64(bytes, tx.Payload.Deposit)
+	bytes = binary.LittleEndian.AppendUint64(bytes, tx.Payload.Fee.GasLimit)
+	bytes = binary.LittleEndian.AppendUint64(bytes, tx.Payload.Fee.GasPrice)
+	if tx.Payload.Fee.RefundAddress != tx.Payload.Sender {
+		refundAddressBytes, err := tx.Payload.Fee.RefundAddress.MarshalBinary()
+		if err != nil {
+			return []xc.TxDataToSign{}, errors.New("failed to marshal refund address")
+		}
+		bytes = append(bytes, refundAddressBytes...)
+	}
+	bytes = binary.LittleEndian.AppendUint64(bytes, tx.Payload.Nonce)
+
+	if len(tx.Payload.Memo) > 0 {
+		bytes = append(bytes, tx.Payload.Memo...)
+	}
+
+	return []xc.TxDataToSign{bytes}, nil
+}
+
+// AddSignatures adds a signature to Tx
+func (tx *Tx) AddSignatures(signatures ...xc.TxSignature) error {
+	if len(signatures) != 1 {
+		return errors.New("only one signature is allowed")
+	}
+
+	if len(tx.Signature) > 0 {
+		return errors.New("transaction already signed")
+	}
+
+	signature := signatures[0]
+	tx.Signature = signature
+
+	return nil
+}
+
+// GetSignatures returns back signatures, which may be used for signed-transaction broadcasting
+func (tx *Tx) GetSignatures() []xc.TxSignature {
+	return []xc.TxSignature{xc.TxSignature(tx.Signature)}
+}
+
+// Serialize returns the serialized tx
+func (tx Tx) Serialize() ([]byte, error) {
+	payload := make([]byte, 0, 0)
+
+	payload = append(payload, tx.Payload.ChainId)
+	senderBytes, err := tx.Payload.Sender.MarshalBinary()
+	if err != nil {
+		return []byte{}, errors.New("failed to marshal sender")
+	}
+	payload = append(payload, senderBytes...)
+
+	if tx.Payload.Sender == tx.Payload.Receiver {
+		payload = append(payload, 0)
+	} else {
+		payload = append(payload, 1)
+		receiverBytes, err := tx.Payload.Receiver.MarshalBinary()
+		if err != nil {
+			return []byte{}, errors.New("failed to marshal receiver")
+		}
+		payload = append(payload, receiverBytes...)
+	}
+
+	payload = binary.LittleEndian.AppendUint64(payload, tx.Payload.Value)
+	payload = binary.LittleEndian.AppendUint64(payload, tx.Payload.Deposit)
+	payload = binary.LittleEndian.AppendUint64(payload, tx.Payload.Fee.GasLimit)
+	payload = binary.LittleEndian.AppendUint64(payload, tx.Payload.Fee.GasPrice)
+
+	if tx.Payload.Fee.RefundAddress == tx.Payload.Sender {
+		payload = append(payload, 0)
+	} else {
+		payload = append(payload, 1)
+		refundAddressBytes, err := tx.Payload.Fee.RefundAddress.MarshalBinary()
+		if err != nil {
+			return []byte{}, errors.New("failed to marshal refund address")
+		}
+		payload = append(payload, refundAddressBytes...)
+	}
+
+	payload = binary.LittleEndian.AppendUint64(payload, tx.Payload.Nonce)
+	if len(tx.Payload.Memo) > 0 {
+		payload = append(payload, tx.Payload.Memo...)
+	} else {
+		payload = append(payload, 0)
+	}
+
+	bytes := make([]byte, 0)
+	// Add 1 for MoonlightTransaction
+	bytes = append(bytes, 1)
+	bytes = binary.LittleEndian.AppendUint64(bytes, uint64(len(payload)))
+	bytes = append(bytes, payload...)
+	bytes = append(bytes, tx.Signature...)
+	return bytes, nil
+}

--- a/chain/dusk/tx/tx.go
+++ b/chain/dusk/tx/tx.go
@@ -66,7 +66,7 @@ func NewTx(args xcbuilder.TransferArgs, input tx_input.TxInput) (Tx, error) {
 
 	tx := Tx{
 		Payload: Payload{
-			ChainId:  1,
+			ChainId:  input.ChainId,
 			Sender:   senderKey,
 			Receiver: receiverKey,
 			Value:    args.GetAmount().Int().Uint64(),

--- a/chain/dusk/tx/tx.go
+++ b/chain/dusk/tx/tx.go
@@ -68,7 +68,7 @@ func NewTx(args xcbuilder.TransferArgs, input tx_input.TxInput) (Tx, error) {
 		return Tx{}, errors.New("failed to get public key from receiver address")
 	}
 
-	refoundKey, err := address.GetPublicKeyFromAddress(input.RefundAccount)
+	refundKey, err := address.GetPublicKeyFromAddress(args.GetFrom())
 	if err != nil {
 		return Tx{}, errors.New("failed to get public key from refund address")
 	}
@@ -87,7 +87,7 @@ func NewTx(args xcbuilder.TransferArgs, input tx_input.TxInput) (Tx, error) {
 			Fee: Fee{
 				GasLimit:      input.GasLimit,
 				GasPrice:      input.GasPrice,
-				RefundAddress: refoundKey,
+				RefundAddress: refundKey,
 			},
 			Nonce: input.Nonce,
 			Memo:  []byte(memo),

--- a/chain/dusk/tx/tx_test.go
+++ b/chain/dusk/tx/tx_test.go
@@ -35,17 +35,9 @@ func TestTxHash(t *testing.T) {
 	require.Equal(t, xc.TxHash("5a9e2b509d1d3bc3fd1479f09671ac80466e63c70297030590086a6cf088331e"), tx.Hash())
 }
 
-func TestTxSighashes(t *testing.T) {
-
-	tx1 := tx.Tx{}
-	sighashes, err := tx1.Sighashes()
-	require.NotNil(t, sighashes)
-	require.EqualError(t, err, "not implemented")
-}
-
 func TestTxAddSignature(t *testing.T) {
 
 	tx1 := tx.Tx{}
 	err := tx1.AddSignatures([]xc.TxSignature{}...)
-	require.EqualError(t, err, "not implemented")
+	require.EqualError(t, err, "only one signature is allowed")
 }

--- a/chain/dusk/tx/tx_test.go
+++ b/chain/dusk/tx/tx_test.go
@@ -67,8 +67,41 @@ func TestTxMemoHash(t *testing.T) {
 }
 
 func TestTxAddSignature(t *testing.T) {
-
-	tx1 := tx.Tx{}
-	err := tx1.AddSignatures([]xc.TxSignature{}...)
+	tx := tx.Tx{}
+	err := tx.AddSignatures([]xc.TxSignature{}...)
 	require.EqualError(t, err, "only one signature is allowed")
+
+	signatures := []xc.TxSignature{xc.TxSignature{}, xc.TxSignature{}}
+	err = tx.AddSignatures(signatures...)
+	require.EqualError(t, err, "only one signature is allowed")
+
+	validSignatures := []xc.TxSignature{xc.TxSignature{}}
+	err = tx.AddSignatures(validSignatures...)
+	require.NoError(t, err)
+}
+
+func TestTxSighashes(t *testing.T) {
+	from := xc.Address("2293LeWtYGpsBA99HRg2AfMm9oYhikZ83GSW5NP6QtQxDvkBTAdU8LfQj9fXvDt1rK1baqBcf3gQKsLXpw3LUjpdkSMRMrTsfuTo5Yri1xvUDnVcMMpgTG4o7ThCjZuLMp9L")
+	to := xc.Address("26nbWp93it1FF8ChyBUmV2zrXMqsv6xR41UUfcyq37abhoYvvEW4C8MgJPdKnzfQhfa6t1VtVj2QUeDK1aP98TGGtumV897Gtv3M7mh2qZBNK6C4LqvP6GyTeHvC7kPncVvg")
+	args, err := builder.NewTransferArgs(
+		from,
+		to,
+		xc.NewAmountBlockchainFromUint64(5_000_000),
+	)
+	require.NoError(t, err)
+
+	tx, err := tx.NewTx(args, tx_input.TxInput{
+		TxInputEnvelope: xc.TxInputEnvelope{},
+		Nonce:           10,
+		GasLimit:        2_500_000,
+		GasPrice:        1,
+		ChainId:         1,
+	})
+	sighashes, err := tx.Sighashes()
+	require.NoError(t, err)
+	if len(sighashes) != 1 {
+		t.Errorf("expected only one sighash")
+	}
+
+	require.Equal(t, sighashes[0], xc.TxDataToSign{1, 171, 173, 120, 172, 251, 40, 146, 34, 146, 117, 120, 193, 28, 248, 42, 251, 9, 132, 119, 117, 185, 53, 45, 65, 109, 60, 173, 87, 208, 217, 120, 148, 18, 1, 96, 102, 130, 217, 165, 163, 115, 64, 3, 59, 203, 41, 164, 134, 14, 66, 146, 90, 63, 210, 16, 148, 224, 181, 74, 149, 165, 149, 236, 79, 105, 168, 0, 208, 132, 70, 222, 211, 136, 71, 164, 161, 214, 237, 106, 139, 215, 239, 33, 85, 170, 116, 200, 212, 204, 87, 228, 148, 89, 137, 135, 79, 185, 43, 78, 21, 106, 5, 164, 108, 112, 150, 226, 145, 220, 213, 232, 22, 185, 168, 148, 244, 62, 227, 28, 53, 87, 161, 206, 156, 109, 17, 31, 117, 200, 178, 212, 13, 211, 15, 215, 91, 143, 28, 196, 56, 217, 118, 76, 142, 20, 134, 148, 30, 204, 49, 196, 49, 5, 110, 179, 32, 189, 248, 113, 44, 226, 226, 105, 15, 171, 5, 84, 245, 138, 98, 230, 216, 99, 185, 80, 31, 18, 108, 47, 225, 135, 224, 123, 122, 148, 144, 124, 249, 107, 33, 55, 225, 64, 75, 76, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 160, 37, 38, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0})
 }

--- a/chain/dusk/tx/tx_test.go
+++ b/chain/dusk/tx/tx_test.go
@@ -1,13 +1,14 @@
 package tx_test
 
 import (
+	"encoding/hex"
 	"testing"
 
 	xc "github.com/cordialsys/crosschain"
 	"github.com/cordialsys/crosschain/builder"
 	"github.com/cordialsys/crosschain/chain/dusk/tx"
 	"github.com/cordialsys/crosschain/chain/dusk/tx_input"
-	"github.com/test-go/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTxHash(t *testing.T) {
@@ -26,13 +27,45 @@ func TestTxHash(t *testing.T) {
 		GasLimit:        2_500_000,
 		GasPrice:        1,
 		RefundAccount:   from,
-		Memo:            "",
 		ChainId:         1,
 	})
 	require.NoError(t, err)
 	tx.Signature = []byte{138, 52, 141, 88, 247, 205, 110, 26, 136, 4, 115, 92, 9, 180, 157, 74, 111, 167, 81, 176, 40, 192, 82, 165, 224, 187, 10, 48, 123, 54, 6, 103, 91, 40, 171, 11, 228, 111, 194, 56, 33, 140, 131, 4, 134, 17, 126, 228}
 
 	require.Equal(t, xc.TxHash("5a9e2b509d1d3bc3fd1479f09671ac80466e63c70297030590086a6cf088331e"), tx.Hash())
+}
+
+func TestTxMemoHash(t *testing.T) {
+	from := xc.Address("2293LeWtYGpsBA99HRg2AfMm9oYhikZ83GSW5NP6QtQxDvkBTAdU8LfQj9fXvDt1rK1baqBcf3gQKsLXpw3LUjpdkSMRMrTsfuTo5Yri1xvUDnVcMMpgTG4o7ThCjZuLMp9L")
+	to := xc.Address("26nbWp93it1FF8ChyBUmV2zrXMqsv6xR41UUfcyq37abhoYvvEW4C8MgJPdKnzfQhfa6t1VtVj2QUeDK1aP98TGGtumV897Gtv3M7mh2qZBNK6C4LqvP6GyTeHvC7kPncVvg")
+	args, err := builder.NewTransferArgs(
+		from,
+		to,
+		xc.NewAmountBlockchainFromUint64(5_000_000),
+		// test memo serialization
+		builder.OptionMemo("1234"),
+	)
+	require.NoError(t, err)
+
+	tx, err := tx.NewTx(args, tx_input.TxInput{
+		TxInputEnvelope: xc.TxInputEnvelope{},
+		Nonce:           10,
+		GasLimit:        2_500_000,
+		GasPrice:        1,
+		RefundAccount:   from,
+		ChainId:         1,
+	})
+	require.NoError(t, err)
+	tx.Signature = []byte{138, 52, 141, 88, 247, 205, 110, 26, 136, 4, 115, 92, 9, 180, 157, 74, 111, 167, 81, 176, 40, 192, 82, 165, 224, 187, 10, 48, 123, 54, 6, 103, 91, 40, 171, 11, 228, 111, 194, 56, 33, 140, 131, 4, 134, 17, 126, 228}
+
+	require.Equal(t, xc.TxHash("e96ccec717989738880f7dc1bba0cdf63b794d32349e7f2c512f91cfab3d2548"), tx.Hash())
+
+	bz, err := tx.Serialize()
+	require.NoError(t, err)
+	require.Equal(t,
+		"01f80000000000000001abad78acfb289222927578c11cf82afb09847775b9352d416d3cad57d0d978941201606682d9a5a37340033bcb29a4860e42925a3fd21094e0b54a95a595ec4f69a800d08446ded38847a4a1d6ed6a8bd7ef2155aa74c8d4cc57e4945989874f01b92b4e156a05a46c7096e291dcd5e816b9a894f43ee31c3557a1ce9c6d111f75c8b2d40dd30fd75b8f1cc438d9764c8e1486941ecc31c431056eb320bdf8712ce2e2690fab0554f58a62e6d863b9501f126c2fe187e07b7a94907cf96b2137e1404b4c00000000000000000000000000a0252600000000000100000000000000000a00000000000000030400000000000000313233348a348d58f7cd6e1a8804735c09b49d4a6fa751b028c052a5e0bb0a307b3606675b28ab0be46fc238218c830486117ee4",
+		hex.EncodeToString(bz),
+	)
 }
 
 func TestTxAddSignature(t *testing.T) {

--- a/chain/dusk/tx/tx_test.go
+++ b/chain/dusk/tx/tx_test.go
@@ -1,0 +1,51 @@
+package tx_test
+
+import (
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/builder"
+	"github.com/cordialsys/crosschain/chain/dusk/tx"
+	"github.com/cordialsys/crosschain/chain/dusk/tx_input"
+	"github.com/test-go/testify/require"
+)
+
+func TestTxHash(t *testing.T) {
+	from := xc.Address("2293LeWtYGpsBA99HRg2AfMm9oYhikZ83GSW5NP6QtQxDvkBTAdU8LfQj9fXvDt1rK1baqBcf3gQKsLXpw3LUjpdkSMRMrTsfuTo5Yri1xvUDnVcMMpgTG4o7ThCjZuLMp9L")
+	to := xc.Address("26nbWp93it1FF8ChyBUmV2zrXMqsv6xR41UUfcyq37abhoYvvEW4C8MgJPdKnzfQhfa6t1VtVj2QUeDK1aP98TGGtumV897Gtv3M7mh2qZBNK6C4LqvP6GyTeHvC7kPncVvg")
+	args, err := builder.NewTransferArgs(
+		from,
+		to,
+		xc.NewAmountBlockchainFromUint64(5_000_000),
+	)
+	require.NoError(t, err)
+
+	tx, err := tx.NewTx(args, tx_input.TxInput{
+		TxInputEnvelope: xc.TxInputEnvelope{},
+		Nonce:           10,
+		GasLimit:        2_500_000,
+		GasPrice:        1,
+		RefundAccount:   from,
+		Memo:            "",
+		ChainId:         1,
+	})
+	require.NoError(t, err)
+	tx.Signature = []byte{138, 52, 141, 88, 247, 205, 110, 26, 136, 4, 115, 92, 9, 180, 157, 74, 111, 167, 81, 176, 40, 192, 82, 165, 224, 187, 10, 48, 123, 54, 6, 103, 91, 40, 171, 11, 228, 111, 194, 56, 33, 140, 131, 4, 134, 17, 126, 228}
+
+	require.Equal(t, xc.TxHash("5a9e2b509d1d3bc3fd1479f09671ac80466e63c70297030590086a6cf088331e"), tx.Hash())
+}
+
+func TestTxSighashes(t *testing.T) {
+
+	tx1 := tx.Tx{}
+	sighashes, err := tx1.Sighashes()
+	require.NotNil(t, sighashes)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestTxAddSignature(t *testing.T) {
+
+	tx1 := tx.Tx{}
+	err := tx1.AddSignatures([]xc.TxSignature{}...)
+	require.EqualError(t, err, "not implemented")
+}

--- a/chain/dusk/tx/tx_test.go
+++ b/chain/dusk/tx/tx_test.go
@@ -26,7 +26,6 @@ func TestTxHash(t *testing.T) {
 		Nonce:           10,
 		GasLimit:        2_500_000,
 		GasPrice:        1,
-		RefundAccount:   from,
 		ChainId:         1,
 	})
 	require.NoError(t, err)
@@ -52,7 +51,6 @@ func TestTxMemoHash(t *testing.T) {
 		Nonce:           10,
 		GasLimit:        2_500_000,
 		GasPrice:        1,
-		RefundAccount:   from,
 		ChainId:         1,
 	})
 	require.NoError(t, err)

--- a/chain/dusk/tx_input/tx_input.go
+++ b/chain/dusk/tx_input/tx_input.go
@@ -1,0 +1,98 @@
+package tx_input
+
+import (
+	"fmt"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/factory/drivers/registry"
+)
+
+// Default gas price for Dusk. Units are LUX - minimum unit of Dusk.
+// 1 LUX = 0.000_000_001 DUSK
+const DEFAULT_GAS_PRICE = 1
+
+// Dusk fee is capped by GasLimit * GasPrice.
+// `(GasLimit - GasUsed) * GasPrice` is returned to specified account.
+// `GasUsed` is the gas cost of the transaction.
+type TxInput struct {
+	xc.TxInputEnvelope
+	Nonce uint64
+	// GasLimit is the maximum amount of gas that can be used for the transaction
+	GasLimit uint64
+	// GasPrice is the amount of gas fee that user is willing to pay per gas
+	GasPrice uint64
+	// Refund account
+	RefundAccount xc.Address
+	Memo          string
+	ChainId       uint8
+}
+
+var _ xc.TxInput = &TxInput{}
+var _ xc.TxInputWithMemo = &TxInput{}
+
+func init() {
+	registry.RegisterTxBaseInput(&TxInput{})
+}
+
+func NewTxInput() *TxInput {
+	return &TxInput{
+		TxInputEnvelope: xc.TxInputEnvelope{
+			Type: xc.DriverDusk,
+		},
+	}
+}
+
+func (input *TxInput) GetDriver() xc.Driver {
+	return xc.DriverDusk
+}
+
+// Adjust `GasLimit` so it satisfies new `feePriority` without affecting `input.GasPrice`
+func (input *TxInput) SetGasFeePriority(feePriority xc.GasFeePriority) error {
+	multiplier, err := feePriority.GetDefault()
+	if err != nil {
+		return err
+	}
+
+	feeLimit := xc.NewAmountBlockchainFromUint64(input.GasLimit * input.GasPrice)
+	var newFeeLimit xc.AmountBlockchain
+
+	if feePriority.IsEnum() {
+		floatMul, _ := multiplier.Float64()
+		newFeeLimit = xc.MultiplyByFloat(feeLimit, floatMul)
+	} else {
+		hrFeeLimit, err := xc.NewAmountHumanReadableFromStr(multiplier.String())
+		if err != nil {
+			return fmt.Errorf("invalid multiplier: %w", err)
+		}
+
+		newFeeLimit = hrFeeLimit.ToBlockchain(9)
+	}
+
+	input.GasLimit = EstimateFeeLimit(newFeeLimit, xc.NewAmountBlockchainFromUint64(input.GasPrice)).Uint64()
+	return nil
+}
+
+// get the max possible fee that could be spent on this transaction
+func (input *TxInput) GetFeeLimit() (xc.AmountBlockchain, xc.ContractAddress) {
+	return xc.NewAmountBlockchainFromUint64(input.GasLimit * input.GasPrice), ""
+}
+
+func (input *TxInput) IndependentOf(other xc.TxInput) (independent bool) {
+	// are these two transactions independent (e.g. different sequences & utxos & expirations?)
+	// default false
+	return
+}
+func (input *TxInput) SafeFromDoubleSend(others ...xc.TxInput) (safe bool) {
+	// safe from double send ?
+	// default false
+	return
+}
+
+func (input *TxInput) SetMemo(memo string) {
+	input.Memo = memo
+}
+
+func EstimateFeeLimit(feeLimit xc.AmountBlockchain, gasPrice xc.AmountBlockchain) xc.AmountBlockchain {
+	gasLimit := feeLimit.Div(&gasPrice)
+	return gasLimit
+}

--- a/chain/dusk/tx_input/tx_input.go
+++ b/chain/dusk/tx_input/tx_input.go
@@ -23,12 +23,10 @@ type TxInput struct {
 	GasPrice uint64
 	// Refund account
 	RefundAccount xc.Address
-	Memo          string
 	ChainId       uint8
 }
 
 var _ xc.TxInput = &TxInput{}
-var _ xc.TxInputWithMemo = &TxInput{}
 
 func init() {
 	registry.RegisterTxBaseInput(&TxInput{})
@@ -86,10 +84,6 @@ func (input *TxInput) SafeFromDoubleSend(others ...xc.TxInput) (safe bool) {
 	// safe from double send ?
 	// default false
 	return
-}
-
-func (input *TxInput) SetMemo(memo string) {
-	input.Memo = memo
 }
 
 func EstimateFeeLimit(feeLimit xc.AmountBlockchain, gasPrice xc.AmountBlockchain) xc.AmountBlockchain {

--- a/chain/dusk/tx_input/tx_input.go
+++ b/chain/dusk/tx_input/tx_input.go
@@ -16,14 +16,12 @@ const DEFAULT_GAS_PRICE = 1
 // `GasUsed` is the gas cost of the transaction.
 type TxInput struct {
 	xc.TxInputEnvelope
-	Nonce uint64
+	Nonce uint64 `json:"nonce"`
 	// GasLimit is the maximum amount of gas that can be used for the transaction
-	GasLimit uint64
+	GasLimit uint64 `json:"gas_limit"`
 	// GasPrice is the amount of gas fee that user is willing to pay per gas
-	GasPrice uint64
-	// Refund account
-	RefundAccount xc.Address
-	ChainId       uint8
+	GasPrice uint64 `json:"gas_price"`
+	ChainId  uint8  `json:"chain_id"`
 }
 
 var _ xc.TxInput = &TxInput{}

--- a/chain/dusk/tx_input/tx_input_test.go
+++ b/chain/dusk/tx_input/tx_input_test.go
@@ -1,0 +1,64 @@
+package tx_input_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/chain/template/tx_input"
+	"github.com/test-go/testify/require"
+)
+
+type TxInput = tx_input.TxInput
+
+func TestSafeFromDoubleSpend(t *testing.T) {
+
+	newInput := &TxInput{}
+	oldInput1 := &TxInput{}
+	// Defaults are false but each chain has conditions
+	require.False(t, newInput.SafeFromDoubleSend(oldInput1))
+	require.False(t, newInput.IndependentOf(oldInput1))
+}
+
+func TestTxInputConflicts(t *testing.T) {
+
+	type testcase struct {
+		newInput xc.TxInput
+		oldInput xc.TxInput
+
+		independent     bool
+		doubleSpendSafe bool
+	}
+	vectors := []testcase{
+		{
+			newInput:        &TxInput{},
+			oldInput:        &TxInput{},
+			independent:     false,
+			doubleSpendSafe: false,
+		},
+		{
+			newInput: &TxInput{},
+			// check no old input
+			oldInput:        nil,
+			independent:     false,
+			doubleSpendSafe: false,
+		},
+	}
+	for i, v := range vectors {
+		newBz, _ := json.Marshal(v.newInput)
+		oldBz, _ := json.Marshal(v.oldInput)
+		fmt.Printf("testcase %d - expect safe=%t, independent=%t\n     newInput = %s\n     oldInput = %s\n", i, v.doubleSpendSafe, v.independent, string(newBz), string(oldBz))
+		fmt.Println()
+		require.Equal(t,
+			v.newInput.IndependentOf(v.oldInput),
+			v.independent,
+			"IndependentOf",
+		)
+		require.Equal(t,
+			v.newInput.SafeFromDoubleSend(v.oldInput),
+			v.doubleSpendSafe,
+			"SafeFromDoubleSend",
+		)
+	}
+}

--- a/client/tx_info.go
+++ b/client/tx_info.go
@@ -218,7 +218,7 @@ func NewTxInfo(block *Block, chainCfg *xc.ChainConfig, hash string, confirmation
 	name := NewTransactionName(chainCfg.Chain, hash)
 
 	state := Succeeded
-	if err != nil {
+	if err != nil && *err != "" {
 		state = Failed
 	} else if block.Height.Uint64() == 0 {
 		state = Mining

--- a/factory/defaults/chains/mainnet.yaml
+++ b/factory/defaults/chains/mainnet.yaml
@@ -359,6 +359,8 @@ chains:
     external:
       coin_market_cap:
         asset_id: "4092"
+      coin_gecko:
+        asset_id: dusk-network
   ETC:
     chain: ETC
     driver: evm-legacy

--- a/factory/defaults/chains/mainnet.yaml
+++ b/factory/defaults/chains/mainnet.yaml
@@ -349,6 +349,16 @@ chains:
         asset_id: "2130"
       coin_gecko:
         asset_id: enjincoin
+  DUSK:
+    chain: DUSK
+    driver: dusk
+    decimals: 9
+    fee_limit: "1.0"
+    chain_name: Dusk
+    confirmations_final: 1
+    external:
+      coin_market_cap:
+        asset_id: "4092"
   ETC:
     chain: ETC
     driver: evm-legacy

--- a/factory/defaults/chains/testnet.yaml
+++ b/factory/defaults/chains/testnet.yaml
@@ -135,6 +135,12 @@ chains:
     chain_prefix: "42"
     indexer_url: "https://rococo.api.subscan.io"
     indexer_type: subscan
+  DUSK:
+    chain: DUSK
+    driver: dusk
+    decimals: 9
+    chain_name: Dusk
+    confirmations_final: 1
   LTC:
     chain: LTC
     driver: bitcoin-legacy

--- a/factory/drivers/factory.go
+++ b/factory/drivers/factory.go
@@ -17,6 +17,10 @@ import (
 	cosmosaddress "github.com/cordialsys/crosschain/chain/cosmos/address"
 	cosmosbuilder "github.com/cordialsys/crosschain/chain/cosmos/builder"
 	cosmosclient "github.com/cordialsys/crosschain/chain/cosmos/client"
+	dusk "github.com/cordialsys/crosschain/chain/dusk"
+	duskaddress "github.com/cordialsys/crosschain/chain/dusk/address"
+	duskbuilder "github.com/cordialsys/crosschain/chain/dusk/builder"
+	duskclient "github.com/cordialsys/crosschain/chain/dusk/client"
 	"github.com/cordialsys/crosschain/chain/evm"
 	evmaddress "github.com/cordialsys/crosschain/chain/evm/address"
 	evmbuilder "github.com/cordialsys/crosschain/chain/evm/builder"
@@ -82,6 +86,8 @@ func NewClient(cfg ITask, driver Driver) (xclient.Client, error) {
 		return xrpclient.NewClient(cfg)
 	case DriverXlm:
 		return xlmclient.NewClient(cfg)
+	case DriverDusk:
+		return duskclient.NewClient(cfg)
 	}
 	return nil, fmt.Errorf("no client defined for chain: %s", string(cfg.GetChain().Chain))
 }
@@ -152,6 +158,8 @@ func NewTxBuilder(cfg *ChainBaseConfig) (xcbuilder.FullTransferBuilder, error) {
 		return xlmbuilder.NewTxBuilder(cfg)
 	case DriverFilecoin:
 		return filbuilder.NewTxBuilder(cfg)
+	case DriverDusk:
+		return duskbuilder.NewTxBuilder(cfg)
 	}
 	return nil, fmt.Errorf("no tx-builder defined for: %s", string(cfg.Chain))
 }
@@ -162,6 +170,8 @@ func NewSigner(chain *ChainBaseConfig, secret string, options ...xcaddress.Addre
 
 func NewAddressBuilder(cfg *ChainBaseConfig, options ...xcaddress.AddressOption) (AddressBuilder, error) {
 	switch Driver(cfg.Driver) {
+	case DriverDusk:
+		return duskaddress.NewAddressBuilder(cfg)
 	case DriverEVM:
 		return evmaddress.NewAddressBuilder(cfg)
 	case DriverEVMLegacy:
@@ -199,6 +209,8 @@ func CheckError(driver Driver, err error) errors.Status {
 		return err.Status
 	}
 	switch driver {
+	case DriverDusk:
+		return dusk.CheckError(err)
 	case DriverEVM:
 		return evm.CheckError(err)
 	case DriverEVMLegacy:

--- a/factory/signer/signer.go
+++ b/factory/signer/signer.go
@@ -147,7 +147,7 @@ func New(driver xc.Driver, secret string, cfgMaybe *xc.ChainBaseConfig, options 
 			return nil, err
 		}
 		return &Signer{driver, secretBz, alg}, nil
-	case xc.Bls:
+	case xc.Bls12_381G2Blake2:
 		return &Signer{driver, secretBz, alg}, nil
 	default:
 		return nil, fmt.Errorf("unsupported signing alg: %v", alg)
@@ -179,7 +179,7 @@ func (s *Signer) Sign(data xc.TxDataToSign) (xc.TxSignature, error) {
 			return nil, err
 		}
 		return signature.Serialize(), nil
-	case xc.Bls:
+	case xc.Bls12_381G2Blake2:
 		var privKey bls.PrivateKey[bls.G2]
 		err := privKey.UnmarshalBinary(s.privateKey)
 		if err != nil {
@@ -244,7 +244,7 @@ func (s *Signer) PublicKey() (PublicKey, error) {
 		default:
 			return crypto.FromECDSAPub(&ecdsaKey.PublicKey), nil
 		}
-	case xc.Bls:
+	case xc.Bls12_381G2Blake2:
 		var blsKey bls.PrivateKey[bls.G2]
 		blsKey.UnmarshalBinary(s.privateKey)
 		return blsKey.PublicKey().MarshalBinary()

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	cosmossdk.io/x/slashing v0.2.0-rc.1
 	cosmossdk.io/x/staking v0.0.0-20241218110910-47409028a73d
 	filippo.io/edwards25519 v1.1.0
+	github.com/cloudflare/circl v1.6.0
 	github.com/fxamacker/cbor v1.5.1
 	golang.org/x/time v0.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -359,6 +359,8 @@ github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/circl v1.6.0 h1:cr5JKic4HI+LkINy2lg3W2jF8sHCVTBncJr5gIIq7qk=
+github.com/cloudflare/circl v1.6.0/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=


### PR DESCRIPTION
This PR introduces the Dusk driver, which relies on following `Rues` endpoints:
- `/on/transactions/propagate`: Propagates a transaction.
- `/on/transactions/preverify`: Verifies a transaction.
- `/on/account:account_id/status`: Fetches balance and nonce.
- `/on/graphql/query`: Fetches transaction information.

Due to some differences between dusk-bls/circl-bls, I had to implement, copy, and/or modify certain methods from circl/bls. These methods are located in the crosschain/chain/dusk/dusk_bls.go file.

Rues documentation: https://docs.dusk.network/developer/integrations/rues

RPCs:
- Mainnet: https://nodes.dusk.network/
- Testnet: https://nodes.testnet.dusk.network/