### PR TITLE
Filecoin: Add EVM txHash to fil cid convertion

### DIFF
--- a/chain/filecoin/client/client_test.go
+++ b/chain/filecoin/client/client_test.go
@@ -302,6 +302,7 @@ func TestFetchTxInfo(t *testing.T) {
 	vectors := []struct {
 		name                    string
 		hash                    string
+		evmHashToCidResponse    string
 		chainGetMessageResponse string
 		stateSearchMsgResponse  string
 		chainGetBlockResponse   string
@@ -314,6 +315,101 @@ func TestFetchTxInfo(t *testing.T) {
 			hash: "bafy2bzacedza344ak7eol4uydlwddlj6igiseftbaomafc3iscsmzoslo65vc",
 			chainGetMessageResponse: `{"result":{
 			  "CID":{"/":"bafy2bzacea5vwrckqz2lin5snjrvuihwdfwumu6hqaibnxwl7dkjwfrntchhi"},
+			  "From":"f13uhmulxtag3qfohj7h2nmtco7e7u3t3nxjdzi7q",
+			  "GasFeeCap":"101183",
+			  "GasLimit":1518203,
+			  "GasPremium":"100129",
+			  "Method":0,
+			  "Nonce":16,
+			  "Params":null,
+			  "To":"f1urvqy4hx5idlki6b6f7ab6hzihjdfy47b5cc6dy",
+			  "Value":"100000000000000000",
+			  "Version":0
+			}}`,
+			stateSearchMsgResponse: `{"result":{
+			  "Height":2440037,
+			  "Message":{"/":"bafy2bzacedza344ak7eol4uydlwddlj6igiseftbaomafc3iscsmzoslo65vc"},
+			  "Receipt":{
+			    "EventsRoot":null,
+			    "ExitCode":0,
+			    "GasUsed":1227563,
+			    "Return":null
+			  },
+			  "TipSet":[
+			    {"/":"bafy2bzacectazjjqvph7rf552wthajzstqy7ylugrstmrloq2m7a6gpri3py6"},
+			    {"/":"bafy2bzacebg3wk2cr62qcfovmrslxtgm23h5v3la7bztimm2iltyke3hgebkg"}
+			  ]
+			}}`,
+			chainGetBlockResponse: `{"result":{
+			  "ParentBaseFee":"100",
+			  "Timestamp":1740527490,
+			  "Height":2440037
+			}}`,
+			chainGetHeadResponse: `{"result":{
+			  "Cids":[
+			    {"/":"bafy2bzaceaoat7pamoo65dedvdyr63ilpilma6q6u3zi4aktkrhndrg7ehxju"},
+			    {"/":"bafy2bzacebgtznsyyctrlhivrscqoqqj6z23fwmtlwdsnqtenbtn2ia2muek6"},
+			    {"/":"bafy2bzacecviu3uzrpvkxcpcekskffs4d6turxs5p3ehyb2gfbynmxomzi7ku"}
+			  ],
+			  "Height":2441667
+			}}`,
+			expectedInfo: xclient.TxInfo{
+				Name:   xclient.TransactionName("chains/FIL/transactions/bafy2bzacedza344ak7eol4uydlwddlj6igiseftbaomafc3iscsmzoslo65vc"),
+				Hash:   "bafy2bzacedza344ak7eol4uydlwddlj6igiseftbaomafc3iscsmzoslo65vc",
+				XChain: xc.NativeAsset("FIL"),
+				Final:  true,
+				Block: &xclient.Block{
+					Chain:  xc.NativeAsset("FIL"),
+					Height: xc.NewAmountBlockchainFromUint64(2440037),
+					Hash:   "bafy2bzacedza344ak7eol4uydlwddlj6igiseftbaomafc3iscsmzoslo65vc",
+					Time:   MustParseTime("1970-01-21T03:28:47.49Z"),
+				},
+				Movements: []*xclient.Movement{
+					NewMovement(
+						"FIL",
+						"FIL",
+						[]*xclient.BalanceChange{
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(100000000000000000),
+								XAddress:  "chains/FIL/addresses/f13uhmulxtag3qfohj7h2nmtco7e7u3t3nxjdzi7q",
+								AddressId: "f13uhmulxtag3qfohj7h2nmtco7e7u3t3nxjdzi7q",
+							},
+						},
+						[]*xclient.BalanceChange{{
+							Balance:   xc.NewAmountBlockchainFromUint64(100000000000000000),
+							XAddress:  "chains/FIL/addresses/f13uhmulxtag3qfohj7h2nmtco7e7u3t3nxjdzi7q",
+							AddressId: "f13uhmulxtag3qfohj7h2nmtco7e7u3t3nxjdzi7q",
+						}},
+					),
+					NewMovement(
+						"FIL",
+						"FIL",
+						[]*xclient.BalanceChange{
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(152138904487),
+								XAddress:  "chains/FIL/addresses/f13uhmulxtag3qfohj7h2nmtco7e7u3t3nxjdzi7q",
+								AddressId: "f13uhmulxtag3qfohj7h2nmtco7e7u3t3nxjdzi7q",
+							},
+						},
+						[]*xclient.BalanceChange{},
+					),
+				},
+				Fees: []*xclient.Balance{
+					{
+						Asset:    "chains/FIL/assets/FIL",
+						Contract: "FIL",
+						Balance:  xc.NewAmountBlockchainFromUint64(152138904487),
+					},
+				},
+				Confirmations: 1630,
+			},
+		},
+		{
+			name:                 "ValidTxEvmHash",
+			hash:                 "bafy2bzacedza344ak7eol4uydlwddlj6igiseftbaomafc3iscsmzoslo65vc",
+			evmHashToCidResponse: `{ "result": { "/": "bafy2bzacea5vwrckqz2lin5snjrvuihwdfwumu6hqaibnxwl7dkjwfrntchhi" }}`,
+			chainGetMessageResponse: `{"result":{
+			  "CID":{"/":"bafy2bzacedza344ak7eol4uydlwddlj6igiseftbaomafc3iscsmzoslo65vc"},
 			  "From":"f13uhmulxtag3qfohj7h2nmtco7e7u3t3nxjdzi7q",
 			  "GasFeeCap":"101183",
 			  "GasLimit":1518203,
@@ -416,6 +512,8 @@ func TestFetchTxInfo(t *testing.T) {
 					w.Write([]byte(v.stateSearchMsgResponse))
 				} else if strings.Contains(rawReq, types.MethodChainGetBlock) {
 					w.Write([]byte(v.chainGetBlockResponse))
+				} else if strings.Contains(rawReq, types.MethodEthGetMessageCidByTransactionHash) {
+					w.Write([]byte(v.evmHashToCidResponse))
 				} else {
 					w.Write([]byte(v.chainGetHeadResponse))
 				}

--- a/chain/filecoin/client/types/rpc.go
+++ b/chain/filecoin/client/types/rpc.go
@@ -6,17 +6,18 @@ import (
 )
 
 const (
-	MethodChainGetBlock             = "Filecoin.ChainGetBlock"
-	MethodChainGetMessage           = "Filecoin.ChainGetMessage"
-	MethodChainGetParentMessages    = "Filecoin.ChainGetParentMessages"
-	MethodChainGetTipSet            = "Filecoin.ChainGetTipSet"
-	MethodChainGetTipSetAfterHeight = "Filecoin.ChainGetTipSetAfterHeight"
-	MethodChainHead                 = "Filecoin.ChainHead"
-	MethodGasEstimateMessageGas     = "Filecoin.GasEstimateMessageGas"
-	MethodMpoolGetNonce             = "Filecoin.MpoolGetNonce"
-	MethodMpoolPush                 = "Filecoin.MpoolPush"
-	MethodStateSearchMsg            = "Filecoin.StateSearchMsg"
-	MethodWalletBallance            = "Filecoin.WalletBalance"
+	MethodChainGetBlock                     = "Filecoin.ChainGetBlock"
+	MethodChainGetMessage                   = "Filecoin.ChainGetMessage"
+	MethodChainGetParentMessages            = "Filecoin.ChainGetParentMessages"
+	MethodChainGetTipSet                    = "Filecoin.ChainGetTipSet"
+	MethodChainGetTipSetAfterHeight         = "Filecoin.ChainGetTipSetAfterHeight"
+	MethodChainHead                         = "Filecoin.ChainHead"
+	MethodEthGetMessageCidByTransactionHash = "Filecoin.EthGetMessageCidByTransactionHash"
+	MethodGasEstimateMessageGas             = "Filecoin.GasEstimateMessageGas"
+	MethodMpoolGetNonce                     = "Filecoin.MpoolGetNonce"
+	MethodMpoolPush                         = "Filecoin.MpoolPush"
+	MethodStateSearchMsg                    = "Filecoin.StateSearchMsg"
+	MethodWalletBallance                    = "Filecoin.WalletBalance"
 )
 
 func NewEmptyParams(method string) Params[[]byte] {
@@ -287,4 +288,17 @@ type ChainGetParentMessagesResponse []CidMessage
 
 func NewChainGetParentMessagesResponse() *Response[ChainGetParentMessagesResponse] {
 	return NewResponse[ChainGetParentMessagesResponse]()
+}
+
+type EthGetMessageCidByTransactionHash string
+
+func (hash *EthGetMessageCidByTransactionHash) MarshalJSON() ([]byte, error) {
+	wrapped := []string{string(*hash)}
+	return json.Marshal(wrapped)
+}
+
+type EvmTxHashToCidResponse Cid
+
+func NewEvmTxHashToCidResponse() *Response[EvmTxHashToCidResponse] {
+	return NewResponse[EvmTxHashToCidResponse]()
 }


### PR DESCRIPTION
This change allows for fetching tx info using either `EvmTxId` or `FilCid`:
- `xc --chain FIL tx-info 0x2b36ac7c024d018f0467c82b77f9654d1dc75059c2cbbb2c574f58efbd394108`
- `xc --chain FIL tx-info bafy2bzaceavtnld4ajgqddyem7ecw57zmvgr3r2qlhbmxozmk5hvr355hfaqq`

We can achieve it in two ways:
- `FilCid -> EvmTxHash` - this requires more work:
    - Implement hex decoding/unmarshaling for eth responses 
    - Replace existing `FetchTxInfo` with a new one, relying on `Filecoin.Eth*` methods
- `EvmTxHash -> FilCid` - this is simple. Add `Filecoin.GasEstimateMessageGas` call and use response with existing `FetchTxInfo`

I decided that less is more and used `EvmTxHash -> FilCid` approach