### PR TITLE
Add cardano support

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -28,6 +28,7 @@ type NativeAsset string
 // List of supported NativeAsset
 const (
 	ACA    = NativeAsset("ACA")    // Acala
+	ADA    = NativeAsset("ADA")    // Cardano
 	AKT    = NativeAsset("AKT")    // Akash
 	APTOS  = NativeAsset("APTOS")  // APTOS
 	ArbETH = NativeAsset("ArbETH") // Arbitrum
@@ -85,6 +86,7 @@ const (
 )
 
 var NativeAssetList []NativeAsset = []NativeAsset{
+	ADA,
 	AKT,
 	BAND,
 	BCH,
@@ -150,6 +152,7 @@ const (
 	DriverBitcoin       = Driver("bitcoin")
 	DriverBitcoinCash   = Driver("bitcoin-cash")
 	DriverBitcoinLegacy = Driver("bitcoin-legacy")
+	DriverCardano       = Driver("cardano")
 	DriverCosmos        = Driver("cosmos")
 	DriverCosmosEvmos   = Driver("evmos")
 	DriverDusk          = Driver("dusk")
@@ -274,6 +277,8 @@ func (native NativeAsset) Driver() Driver {
 		return DriverFilecoin
 	case DUSK:
 		return DriverDusk
+	case ADA:
+		return DriverCardano
 	}
 	return ""
 }
@@ -284,7 +289,7 @@ func (driver Driver) SignatureAlgorithm() SignatureType {
 		return K256Sha256
 	case DriverEVM, DriverEVMLegacy, DriverCosmosEvmos, DriverTron:
 		return K256Keccak
-	case DriverAptos, DriverSolana, DriverSui, DriverTon, DriverSubstrate, DriverXlm:
+	case DriverAptos, DriverSolana, DriverSui, DriverTon, DriverSubstrate, DriverXlm, DriverCardano:
 		return Ed255
 	case DriverDusk:
 		return Bls12_381G2Blake2

--- a/asset.go
+++ b/asset.go
@@ -305,7 +305,7 @@ var Uncompressed PublicKeyFormat = "uncompressed"
 
 func (driver Driver) PublicKeyFormat() PublicKeyFormat {
 	switch driver {
-	case DriverBitcoin, DriverBitcoinCash, DriverBitcoinLegacy:
+	case DriverBitcoin, DriverCardano, DriverBitcoinCash, DriverBitcoinLegacy:
 		return Compressed
 	case DriverCosmos, DriverCosmosEvmos, DriverXrp, DriverXlm:
 		return Compressed

--- a/chain/cardano/address/address.go
+++ b/chain/cardano/address/address.go
@@ -1,0 +1,64 @@
+package address
+
+import (
+	"fmt"
+	"strings"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cosmos/btcutil/bech32"
+	"golang.org/x/crypto/blake2b"
+)
+
+const (
+	AddressTypePaymentKeyHash = 0b0110_0000
+	NetworkTagTestnet         = 0b0000_0000
+	NetworkTagMainnet         = 0b0000_0001
+)
+
+// AddressBuilder for Template
+type AddressBuilder struct {
+	IsMainnet bool
+}
+
+var _ xc.AddressBuilder = AddressBuilder{}
+
+// NewAddressBuilder creates a new Template AddressBuilder
+func NewAddressBuilder(cfgI *xc.ChainBaseConfig) (xc.AddressBuilder, error) {
+	return AddressBuilder{
+		IsMainnet: cfgI.Network == "" || strings.ToLower(cfgI.Network) == "mainnet",
+	}, nil
+}
+
+// GetAddressFromPublicKey returns an Address given a public key
+func (ab AddressBuilder) GetAddressFromPublicKey(publicKeyBytes []byte) (xc.Address, error) {
+	var hrm string
+	// Header consists of 2 parts:
+	// - [0..4] bits: Address type
+	// - [4..8] bits: Network tag
+	var header byte
+
+	if ab.IsMainnet {
+		hrm = "addr"
+		header = AddressTypePaymentKeyHash | NetworkTagMainnet
+	} else {
+		hrm = "addr_test"
+		header = AddressTypePaymentKeyHash | NetworkTagTestnet
+	}
+
+	b2b, err := blake2b.New(28, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create blake2b hash: %w", err)
+	}
+	b2b.Write(publicKeyBytes)
+	addrHash := b2b.Sum(nil)
+
+	addrBytes := []byte{header}
+	addrBytes = append(addrBytes, addrHash...)
+
+	bech, err := bech32.EncodeFromBase256(hrm, addrBytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode address: %w", err)
+	}
+
+	return xc.Address(bech), nil
+}

--- a/chain/cardano/address/address.go
+++ b/chain/cardano/address/address.go
@@ -31,6 +31,10 @@ func NewAddressBuilder(cfgI *xc.ChainBaseConfig) (xc.AddressBuilder, error) {
 
 // GetAddressFromPublicKey returns an Address given a public key
 func (ab AddressBuilder) GetAddressFromPublicKey(publicKeyBytes []byte) (xc.Address, error) {
+	if len(publicKeyBytes) != 32 {
+		return "", fmt.Errorf("invalid public key length: %d, expected 32", len(publicKeyBytes))
+	}
+
 	var hrm string
 	// Header consists of 2 parts:
 	// - [0..4] bits: Address type

--- a/chain/cardano/address/address_test.go
+++ b/chain/cardano/address/address_test.go
@@ -1,0 +1,24 @@
+package address_test
+
+import (
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/chain/template/address"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAddressBuilder(t *testing.T) {
+
+	builder, err := address.NewAddressBuilder(xc.NewChainConfig("XYZ").Base())
+	require.NotNil(t, builder)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestGetAddressFromPublicKey(t *testing.T) {
+
+	builder, _ := address.NewAddressBuilder(xc.NewChainConfig("XYZ").Base())
+	address, err := builder.GetAddressFromPublicKey([]byte{})
+	require.Equal(t, xc.Address(""), address)
+	require.EqualError(t, err, "not implemented")
+}

--- a/chain/cardano/address/address_test.go
+++ b/chain/cardano/address/address_test.go
@@ -1,24 +1,82 @@
 package address_test
 
 import (
+	"encoding/hex"
 	"testing"
 
 	xc "github.com/cordialsys/crosschain"
-	"github.com/cordialsys/crosschain/chain/template/address"
+	"github.com/cordialsys/crosschain/chain/cardano/address"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewAddressBuilder(t *testing.T) {
+func TestMainnetAddressBuilder(t *testing.T) {
+	cfg := xc.NewChainConfig(xc.ADA).WithNet("mainnet")
+	builder, err := address.NewAddressBuilder(cfg.Base())
 
-	builder, err := address.NewAddressBuilder(xc.NewChainConfig("XYZ").Base())
+	require.NoError(t, err)
 	require.NotNil(t, builder)
-	require.EqualError(t, err, "not implemented")
+	require.Equal(t, true, builder.(address.AddressBuilder).IsMainnet)
+}
+
+func TestPreprodAddressBuilder(t *testing.T) {
+	cfg := xc.NewChainConfig(xc.ADA).WithNet("preprod")
+	builder, err := address.NewAddressBuilder(cfg.Base())
+
+	require.NoError(t, err)
+	require.NotNil(t, builder)
+	require.Equal(t, false, builder.(address.AddressBuilder).IsMainnet)
 }
 
 func TestGetAddressFromPublicKey(t *testing.T) {
+	vetors := []struct {
+		name            string
+		network         string
+		pubkey          string
+		expectedAddress string
+		error           string
+	}{
+		{
+			name:            "PreprodNetwork",
+			network:         "preprod",
+			pubkey:          "d6ed91f336502ff706d97729d7ab5521e230c39353ca79372d2b1fc239eaa72c",
+			expectedAddress: "addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5",
+		},
+		{
+			name:    "StagingNetwork",
+			network: "staging",
+			pubkey:  "d6ed91f336502ff706d97729d7ab5521e230c39353ca79372d2b1fc239eaa72c",
+			// Address HMR differs only for mainnet
+			expectedAddress: "addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5",
+		},
+		{
+			name:            "MainnetNetwork",
+			network:         "mainnet",
+			pubkey:          "d6ed91f336502ff706d97729d7ab5521e230c39353ca79372d2b1fc239eaa72c",
+			expectedAddress: "addr1vxjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s02dyt3",
+		},
+		{
+			name:            "PubkeyTooLong",
+			network:         "mainnet",
+			pubkey:          "d6ed91f336502ff706d97729d7ab5521e230c39353ca79372d2b1fc239eaa72caaaaaa",
+			expectedAddress: "addr1vxjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s02dyt3",
+			error:           "invalid public key length",
+		},
+	}
 
-	builder, _ := address.NewAddressBuilder(xc.NewChainConfig("XYZ").Base())
-	address, err := builder.GetAddressFromPublicKey([]byte{})
-	require.Equal(t, xc.Address(""), address)
-	require.EqualError(t, err, "not implemented")
+	for _, v := range vetors {
+		t.Run(v.name, func(t *testing.T) {
+			cfg := xc.NewChainConfig(xc.ADA).WithNet(v.network)
+			builder, err := address.NewAddressBuilder(cfg.Base())
+			require.NoError(t, err)
+
+			pubkeyBytes, err := hex.DecodeString(v.pubkey)
+			address, err := builder.GetAddressFromPublicKey(pubkeyBytes)
+			if v.error == "" {
+				require.NoError(t, err)
+				require.Equal(t, v.expectedAddress, string(address))
+			} else {
+				require.ErrorContains(t, err, v.error)
+			}
+		})
+	}
 }

--- a/chain/cardano/builder/builder.go
+++ b/chain/cardano/builder/builder.go
@@ -1,7 +1,6 @@
 package builder
 
 import (
-	"errors"
 	"fmt"
 
 	xc "github.com/cordialsys/crosschain"
@@ -10,10 +9,8 @@ import (
 	cardanoinput "github.com/cordialsys/crosschain/chain/cardano/tx_input"
 )
 
-// TxBuilder for Template
-type TxBuilder struct {
-	Asset *xc.ChainBaseConfig
-}
+// Cardano TxBuilder
+type TxBuilder struct{}
 
 type TxInput = cardanoinput.TxInput
 
@@ -21,31 +18,15 @@ var _ xcbuilder.FullTransferBuilder = TxBuilder{}
 
 // NewTxBuilder creates a new Template TxBuilder
 func NewTxBuilder(cfgI *xc.ChainBaseConfig) (TxBuilder, error) {
-	return TxBuilder{
-		Asset: cfgI,
-	}, nil
+	return TxBuilder{}, nil
 }
 
 // NewTransfer creates a new transfer for an Asset, either native or token
 func (txBuilder TxBuilder) Transfer(args xcbuilder.TransferArgs, input xc.TxInput) (xc.Tx, error) {
-	if contract, ok := args.GetContract(); ok {
-		return txBuilder.NewTokenTransfer(args, contract, input)
-	} else {
-		return txBuilder.NewNativeTransfer(args, input)
-	}
-}
-
-// NewNativeTransfer creates a new transfer for a native asset
-func (txBuilder TxBuilder) NewNativeTransfer(args xcbuilder.TransferArgs, input xc.TxInput) (xc.Tx, error) {
 	txInput, ok := input.(*TxInput)
 	if !ok {
 		return nil, fmt.Errorf("invalid input type")
 	}
 
 	return tx.NewTx(args, *txInput)
-}
-
-// NewTokenTransfer creates a new transfer for a token asset
-func (txBuilder TxBuilder) NewTokenTransfer(args xcbuilder.TransferArgs, contract xc.ContractAddress, input xc.TxInput) (xc.Tx, error) {
-	return nil, errors.New("not implemented")
 }

--- a/chain/cardano/builder/builder.go
+++ b/chain/cardano/builder/builder.go
@@ -1,0 +1,51 @@
+package builder
+
+import (
+	"errors"
+	"fmt"
+
+	xc "github.com/cordialsys/crosschain"
+	xcbuilder "github.com/cordialsys/crosschain/builder"
+	tx "github.com/cordialsys/crosschain/chain/cardano/tx"
+	cardanoinput "github.com/cordialsys/crosschain/chain/cardano/tx_input"
+)
+
+// TxBuilder for Template
+type TxBuilder struct {
+	Asset *xc.ChainBaseConfig
+}
+
+type TxInput = cardanoinput.TxInput
+
+var _ xcbuilder.FullTransferBuilder = TxBuilder{}
+
+// NewTxBuilder creates a new Template TxBuilder
+func NewTxBuilder(cfgI *xc.ChainBaseConfig) (TxBuilder, error) {
+	return TxBuilder{
+		Asset: cfgI,
+	}, nil
+}
+
+// NewTransfer creates a new transfer for an Asset, either native or token
+func (txBuilder TxBuilder) Transfer(args xcbuilder.TransferArgs, input xc.TxInput) (xc.Tx, error) {
+	if contract, ok := args.GetContract(); ok {
+		return txBuilder.NewTokenTransfer(args, contract, input)
+	} else {
+		return txBuilder.NewNativeTransfer(args, input)
+	}
+}
+
+// NewNativeTransfer creates a new transfer for a native asset
+func (txBuilder TxBuilder) NewNativeTransfer(args xcbuilder.TransferArgs, input xc.TxInput) (xc.Tx, error) {
+	txInput, ok := input.(*TxInput)
+	if !ok {
+		return nil, fmt.Errorf("invalid input type")
+	}
+
+	return tx.NewTx(args, *txInput)
+}
+
+// NewTokenTransfer creates a new transfer for a token asset
+func (txBuilder TxBuilder) NewTokenTransfer(args xcbuilder.TransferArgs, contract xc.ContractAddress, input xc.TxInput) (xc.Tx, error) {
+	return nil, errors.New("not implemented")
+}

--- a/chain/cardano/builder/builder_test.go
+++ b/chain/cardano/builder/builder_test.go
@@ -1,0 +1,46 @@
+package builder_test
+
+import (
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/builder/buildertest"
+	"github.com/cordialsys/crosschain/chain/template/builder"
+	"github.com/cordialsys/crosschain/chain/template/tx_input"
+	"github.com/stretchr/testify/require"
+)
+
+type TxInput = tx_input.TxInput
+
+func TestNewTxBuilder(t *testing.T) {
+	builder1, err := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
+	require.NotNil(t, builder1)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestNewNativeTransfer(t *testing.T) {
+	builder, _ := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
+	from := xc.Address("from")
+	to := xc.Address("to")
+	amount := xc.AmountBlockchain{}
+	input := &TxInput{}
+	args := buildertest.MustNewTransferArgs(
+		from, to, amount,
+	)
+	_, err := builder.Transfer(args, input)
+	require.ErrorContains(t, err, "not implemented")
+}
+
+func TestNewTokenTransfer(t *testing.T) {
+	builder1, _ := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
+	from := xc.Address("from")
+	to := xc.Address("to")
+	amount := xc.AmountBlockchain{}
+	input := &TxInput{}
+	args := buildertest.MustNewTransferArgs(
+		from, to, amount,
+		buildertest.OptionContractAddress(xc.ContractAddress("contract")),
+	)
+	_, err := builder1.Transfer(args, input)
+	require.ErrorContains(t, err, "token transfers are not supported for XYZ")
+}

--- a/chain/cardano/builder/builder_test.go
+++ b/chain/cardano/builder/builder_test.go
@@ -1,46 +1,87 @@
 package builder_test
 
 import (
+	"encoding/hex"
 	"testing"
 
 	xc "github.com/cordialsys/crosschain"
-	"github.com/cordialsys/crosschain/builder/buildertest"
-	"github.com/cordialsys/crosschain/chain/template/builder"
-	"github.com/cordialsys/crosschain/chain/template/tx_input"
+	xcbuilder "github.com/cordialsys/crosschain/builder"
+	"github.com/cordialsys/crosschain/chain/cardano/builder"
+	"github.com/cordialsys/crosschain/chain/cardano/client/types"
+	"github.com/cordialsys/crosschain/chain/cardano/tx"
+	"github.com/cordialsys/crosschain/chain/cardano/tx_input"
 	"github.com/stretchr/testify/require"
 )
 
 type TxInput = tx_input.TxInput
 
 func TestNewTxBuilder(t *testing.T) {
-	builder1, err := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
+	builder1, err := builder.NewTxBuilder(xc.NewChainConfig(xc.ADA).Base())
 	require.NotNil(t, builder1)
-	require.EqualError(t, err, "not implemented")
+	require.NoError(t, err)
 }
 
 func TestNewNativeTransfer(t *testing.T) {
-	builder, _ := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
-	from := xc.Address("from")
-	to := xc.Address("to")
-	amount := xc.AmountBlockchain{}
-	input := &TxInput{}
-	args := buildertest.MustNewTransferArgs(
-		from, to, amount,
-	)
-	_, err := builder.Transfer(args, input)
-	require.ErrorContains(t, err, "not implemented")
-}
+	fromAddr := xc.Address("addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5")
 
-func TestNewTokenTransfer(t *testing.T) {
-	builder1, _ := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
-	from := xc.Address("from")
-	to := xc.Address("to")
-	amount := xc.AmountBlockchain{}
-	input := &TxInput{}
-	args := buildertest.MustNewTransferArgs(
-		from, to, amount,
-		buildertest.OptionContractAddress(xc.ContractAddress("contract")),
-	)
-	_, err := builder1.Transfer(args, input)
-	require.ErrorContains(t, err, "token transfers are not supported for XYZ")
+	toAddr := xc.Address("addr_test1qrfp5xelv2mu7k8zyvwm0c8t5xm55wanwhtd4fgjgtf3ck0rplhn7x9jyhwqg70fwv0ujpmyumqk5td9e9hnsejtlxnq3yqf25")
+	_, expectedToKey, err := tx.DecodeToBase256(string(toAddr))
+
+	amount := xc.NewAmountBlockchainFromUint64(1_000_000)
+	transferArgs, err := xcbuilder.NewTransferArgs(fromAddr, toAddr, amount)
+	require.NoError(t, err)
+
+	expectedUtxoHash := "72cfa181469b48402a50c6652d45c789897ae5025bb01f569a7bd01bffd12bc1"
+	expectedUtxoIndex := uint16(1)
+	expectedUtxoAmount := "5333004"
+	xcInputAmount := xc.NewAmountBlockchainFromStr(expectedUtxoAmount)
+	transferInput := tx_input.TxInput{
+		Utxos: []types.Utxo{
+			{
+				Address: "addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5",
+				Amounts: []types.Amount{
+					{
+						Unit:     "lovelace",
+						Quantity: expectedUtxoAmount,
+					},
+				},
+				TxHash: expectedUtxoHash,
+				Index:  expectedUtxoIndex,
+			},
+		},
+		Slot:             90_751_416,
+		FixedFee:         xc.NewAmountBlockchainFromUint64(155_381),
+		FeePerByte:       xc.NewAmountBlockchainFromUint64(44),
+		MinUtxo:          xc.NewAmountBlockchainFromUint64(4_310),
+		CoinsPerUtxoWord: xc.NewAmountBlockchainFromUint64(4_310),
+	}
+
+	cfg := xc.NewChainConfig(xc.ADA).WithNet("preprod").WithDecimals(6)
+	builder, err := builder.NewTxBuilder(cfg.Base())
+	require.NoError(t, err)
+
+	transfer, err := builder.Transfer(transferArgs, &transferInput)
+	require.NoError(t, err)
+
+	cardanoTx, ok := transfer.(*tx.Tx)
+	require.True(t, ok)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedUtxoHash, hex.EncodeToString(cardanoTx.Body.Inputs[0].TxHash))
+	require.Equal(t, expectedUtxoIndex, cardanoTx.Body.Inputs[0].Index)
+
+	// Expect 2 outputs: to receiver, and change
+	output0 := cardanoTx.Body.Outputs[0]
+	output1 := cardanoTx.Body.Outputs[1]
+	require.Equal(t, 2, len(cardanoTx.Body.Outputs))
+	require.Equal(t, expectedToKey, output0.Address)
+
+	output0Amount := xc.NewAmountBlockchainFromUint64(output0.TokenAmounts.NativeAmount)
+	xcInputAmount = xcInputAmount.Sub(&output0Amount)
+	output1Amount := xc.NewAmountBlockchainFromUint64(output1.TokenAmounts.NativeAmount)
+	xcInputAmount = xcInputAmount.Sub(&output1Amount)
+	feeAmount := xc.NewAmountBlockchainFromUint64(cardanoTx.Body.Fee)
+	xcInputAmount = xcInputAmount.Sub(&feeAmount)
+
+	require.Zero(t, xcInputAmount.Uint64())
 }

--- a/chain/cardano/builder/builder_test.go
+++ b/chain/cardano/builder/builder_test.go
@@ -49,11 +49,7 @@ func TestNewNativeTransfer(t *testing.T) {
 				Index:  expectedUtxoIndex,
 			},
 		},
-		Slot:             90_751_416,
-		FixedFee:         xc.NewAmountBlockchainFromUint64(155_381),
-		FeePerByte:       xc.NewAmountBlockchainFromUint64(44),
-		MinUtxo:          xc.NewAmountBlockchainFromUint64(4_310),
-		CoinsPerUtxoWord: xc.NewAmountBlockchainFromUint64(4_310),
+		Slot: 90_751_416,
 	}
 
 	cfg := xc.NewChainConfig(xc.ADA).WithNet("preprod").WithDecimals(6)

--- a/chain/cardano/client/client.go
+++ b/chain/cardano/client/client.go
@@ -175,7 +175,7 @@ func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.Tra
 	}
 	cbor, err := dummyTx.Serialize()
 	if err != nil {
-		return nil, fmt.Errorf("failed to serialize fee stimation transaction: %w", err)
+		return nil, fmt.Errorf("failed to serialize fee estimation transaction: %w", err)
 	}
 	txSize := len(cbor)
 	txInput.Fee = protocolParams.FeePerByte*uint64(txSize) + protocolParams.FixedFee + FeeMargin

--- a/chain/cardano/client/client.go
+++ b/chain/cardano/client/client.go
@@ -1,0 +1,397 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"slices"
+	"time"
+
+	xc "github.com/cordialsys/crosschain"
+	xcbuilder "github.com/cordialsys/crosschain/builder"
+	"github.com/cordialsys/crosschain/chain/cardano/client/types"
+	"github.com/cordialsys/crosschain/chain/cardano/tx_input"
+	xclient "github.com/cordialsys/crosschain/client"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	POST = "POST"
+	GET  = "GET"
+	// Cardano uses lovelace as the smallest unit of ada
+	// 1 lovelace = 0.000001 ada
+	LOVELACE    = "lovelace"
+	API_VERSION = "/api/v0"
+)
+
+// Client for Template
+type Client struct {
+	Asset      xc.ITask
+	Url        string
+	Network    string
+	Logger     *log.Entry
+	ProjectId  string
+	HttpClient *http.Client
+}
+
+var _ xclient.Client = &Client{}
+
+// NewClient returns a new Template Client
+func NewClient(cfgI xc.ITask) (*Client, error) {
+	cfg := cfgI.GetChain()
+	url := cfg.GetChain().URL
+	if url == "" {
+		return nil, errors.New("rpc url is empty")
+	}
+
+	network := cfg.GetChain().Network
+	if network == "" {
+		return nil, errors.New("rpc url is empty")
+	}
+
+	logger := log.WithFields(log.Fields{
+		"chain":   cfg.Chain,
+		"rpc":     url,
+		"network": network,
+	})
+
+	return &Client{
+		Asset:   cfgI,
+		Url:     url,
+		Network: network,
+		Logger:  logger,
+		// Not all providers require api key
+		ProjectId:  cfg.Auth2.LoadOrBlank(),
+		HttpClient: http.DefaultClient,
+	}, nil
+}
+
+func (client *Client) FetchProtocolParameters(ctx context.Context) (types.ProtocolParameters, error) {
+	var protocolParameters types.ProtocolParameters
+	err := client.Request(ctx, GET, "/epochs/latest/parameters", "", &protocolParameters)
+
+	return protocolParameters, err
+}
+
+func (client *Client) FetchUtxos(ctx context.Context, address xc.Address, contract xc.ContractAddress) ([]types.Utxo, error) {
+	path := fmt.Sprintf("/addresses/%s/utxos/%s?order=desc", string(address), string(contract))
+	var response []types.Utxo
+	err := client.Request(ctx, GET, path, "", &response)
+	return response, err
+}
+
+// 1. Sort utxos by amount descending
+// 2. Get minimum utxo set that adds up to the target amount
+func GetMinUtxoSet(utxos []types.Utxo, targetAmount xc.AmountBlockchain, contract xc.ContractAddress) []types.Utxo {
+	slices.SortFunc(utxos, func(lhs types.Utxo, rhs types.Utxo) int {
+		amountL := lhs.GetAssetAmount(contract)
+		amountR := rhs.GetAssetAmount(contract)
+
+		return amountR.Cmp(&amountL)
+	})
+
+	utxoSet := make([]types.Utxo, 0)
+	balance := xc.NewAmountBlockchainFromUint64(0)
+	for _, utxo := range utxos {
+		if balance.Cmp(&targetAmount) >= 0 {
+			break
+		}
+
+		amount := utxo.GetAssetAmount(contract)
+		balance = balance.Add(&amount)
+		utxoSet = append(utxoSet, utxo)
+	}
+	return utxoSet
+}
+
+// FetchTransferInput returns tx input for a Cardano transfer
+func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.TransferArgs) (xc.TxInput, error) {
+	decimals, err := client.FetchDecimals(ctx, LOVELACE)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch decimals: %w", err)
+	}
+
+	contract, ok := args.GetContract()
+	if !ok {
+		contract = LOVELACE
+	}
+
+	utxos, err := client.FetchUtxos(ctx, args.GetFrom(), contract)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch utxos: %w", err)
+	}
+
+	// Include the fee in target amount
+	cfg := client.Asset.GetChain()
+	feeLimit := cfg.FeeLimit
+	xfeeLimit := feeLimit.ToBlockchain(int32(decimals))
+	targetAmount := args.GetAmount()
+	targetAmount.Add(&xfeeLimit)
+
+	utxos = GetMinUtxoSet(utxos, targetAmount, contract)
+
+	var latestBlock types.Block
+	err = client.Request(ctx, GET, "/blocks/latest", "", &latestBlock)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch block info: %w", err)
+	}
+
+	protocolParams, err := client.FetchProtocolParameters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch protocol parameters: %w", err)
+	}
+
+	baseFee := protocolParams.FixedFee
+	feePerByte := protocolParams.FeePerByte
+
+	return &tx_input.TxInput{
+		Utxos:            utxos,
+		FixedFee:         xc.NewAmountBlockchainFromUint64(baseFee),
+		FeePerByte:       xc.NewAmountBlockchainFromUint64(feePerByte),
+		Slot:             latestBlock.Slot,
+		MinUtxo:          xc.NewAmountBlockchainFromStr(protocolParams.MinUtxoValue),
+		CoinsPerUtxoWord: xc.NewAmountBlockchainFromStr(protocolParams.CoinsPerUtxoWord),
+	}, nil
+}
+
+// Deprecated method - use FetchTransferInput
+func (client *Client) FetchLegacyTxInput(ctx context.Context, from xc.Address, to xc.Address) (xc.TxInput, error) {
+	// No way to pass the amount in the input using legacy interface, so we estimate using min amount.
+	args, _ := xcbuilder.NewTransferArgs(from, to, xc.NewAmountBlockchainFromUint64(1))
+	return client.FetchTransferInput(ctx, args)
+}
+
+// SubmitTx submits a Template tx
+func (client *Client) SubmitTx(ctx context.Context, tx xc.Tx) error {
+	bytes, err := tx.Serialize()
+	if err != nil {
+		return fmt.Errorf("failed to serialize tx: %w", err)
+	}
+	cborHex := hex.EncodeToString(bytes)
+
+	var response string
+	err = client.Request(ctx, POST, "/tx/submit", cborHex, &response)
+	if err != nil {
+		return fmt.Errorf("failed to submit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// Returns transaction info - legacy/old endpoint
+func (client *Client) FetchLegacyTxInfo(ctx context.Context, txHash xc.TxHash) (xclient.LegacyTxInfo, error) {
+	return xclient.LegacyTxInfo{}, errors.New("deprecated")
+}
+
+// Returns transaction info - new endpoint
+func (client *Client) FetchTxInfo(ctx context.Context, txHash xc.TxHash) (xclient.TxInfo, error) {
+	var latestBlock types.Block
+	err := client.Request(ctx, GET, "/blocks/latest", "", &latestBlock)
+	if err != nil {
+		return xclient.TxInfo{}, fmt.Errorf("failed to fetch latest block: %w", err)
+	}
+
+	var transactionInfo types.TransactionInfo
+	transactionPath := fmt.Sprintf("/txs/%s", string(txHash))
+	err = client.Request(ctx, GET, transactionPath, "", &transactionInfo)
+	if err != nil {
+		return xclient.TxInfo{}, fmt.Errorf("failed to fetch transaction info: %w", err)
+	}
+
+	var blockInfo types.Block
+	blockPath := fmt.Sprintf("/blocks/%d", transactionInfo.BlockHeight)
+	err = client.Request(ctx, GET, blockPath, "", &blockInfo)
+	if err != nil {
+		return xclient.TxInfo{}, fmt.Errorf("failed to fetch block info: %w", err)
+	}
+
+	chain := client.Asset.GetChain().Chain
+	timestamp := time.Unix(blockInfo.Time, 0)
+	block := xclient.NewBlock(
+		chain,
+		uint64(transactionInfo.BlockHeight),
+		blockInfo.Hash,
+		timestamp,
+	)
+
+	txInfo := xclient.NewTxInfo(
+		block,
+		client.Asset.GetChain(),
+		string(txHash),
+		blockInfo.Confirmations,
+		nil,
+	)
+
+	var transactionUtxos types.TransactionUtxos
+	transactionUtxosPath := fmt.Sprintf("%s/utxos", transactionPath)
+	err = client.Request(ctx, GET, transactionUtxosPath, "", &transactionUtxos)
+	if err != nil {
+		return xclient.TxInfo{}, fmt.Errorf("failed to fetch transaction utxos: %w", err)
+	}
+	contractToMovement := make(map[xc.ContractAddress]*xclient.Movement)
+	for _, input := range transactionUtxos.Inputs {
+		addr := xc.Address(input.Address)
+		for _, amount := range input.Amounts {
+			contract := xc.ContractAddress(amount.Unit)
+			if contractToMovement[contract] == nil {
+				contractToMovement[contract] = xclient.NewMovement(
+					xc.ADA,
+					contract,
+				)
+			}
+			contractToMovement[contract].AddSource(addr, xc.NewAmountBlockchainFromStr(amount.Quantity), nil)
+		}
+	}
+
+	for _, output := range transactionUtxos.Outputs {
+		addr := xc.Address(output.Address)
+		for _, amount := range output.Amounts {
+			contract := xc.ContractAddress(amount.Unit)
+			if contractToMovement[contract] == nil {
+				contractToMovement[contract] = xclient.NewMovement(
+					xc.ADA,
+					contract,
+				)
+			}
+			contractToMovement[contract].AddDestination(addr, xc.NewAmountBlockchainFromStr(amount.Quantity), nil)
+		}
+	}
+
+	movements := slices.Collect(maps.Values(contractToMovement))
+	txInfo.Movements = movements
+
+	feeAmount := xc.NewAmountBlockchainFromStr(transactionInfo.Fees)
+	feeAccount := xc.Address(transactionUtxos.Inputs[0].Address)
+	txInfo.AddFee(feeAccount, LOVELACE, feeAmount, nil)
+
+	return *txInfo, nil
+}
+
+func (client *Client) FetchBalance(ctx context.Context, args *xclient.BalanceArgs) (xc.AmountBlockchain, error) {
+	path := fmt.Sprintf("/addresses/%s", string(args.Address()))
+	var getAddressInfoResponse types.GetAddressInfoResponse
+	err := client.Request(ctx, GET, path, "", &getAddressInfoResponse)
+	if err != nil {
+		return xc.AmountBlockchain{}, fmt.Errorf("failed to fetch address info: %w", err)
+	}
+
+	contract, ok := args.Contract()
+	if !ok {
+		contract = LOVELACE
+	}
+
+	for _, amount := range getAddressInfoResponse.Amounts {
+		if amount.Unit == string(contract) {
+			return xc.NewAmountBlockchainFromStr(amount.Quantity), nil
+		}
+	}
+
+	return xc.NewAmountBlockchainFromUint64(0), nil
+}
+
+func (client *Client) FetchDecimals(ctx context.Context, contract xc.ContractAddress) (int, error) {
+	return 6, nil
+}
+
+func (client *Client) FetchBlock(ctx context.Context, args *xclient.BlockArgs) (*xclient.BlockWithTransactions, error) {
+	height, ok := args.Height()
+	var blockPath string
+	if ok {
+		blockPath = fmt.Sprintf("/blocks/%d", height)
+	} else {
+		blockPath = "/blocks/latest"
+	}
+	var block types.Block
+	err := client.Request(ctx, GET, blockPath, "", &block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch block info: %w", err)
+	}
+
+	xBlock := xclient.NewBlock(
+		client.Asset.GetChain().Chain,
+		height,
+		block.Hash,
+		time.Unix(block.Time, 0),
+	)
+
+	blockTransactionsPaths := fmt.Sprintf("%s/txs", blockPath)
+	transactionHashes := make([]string, 0)
+	err = client.Request(ctx, GET, blockTransactionsPaths, "", &transactionHashes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch block transactions: %w", err)
+	}
+
+	return &xclient.BlockWithTransactions{
+		Block:          *xBlock,
+		TransactionIds: transactionHashes,
+	}, nil
+}
+
+func (client *Client) Request(ctx context.Context, method string, path string, cbor string, resp any) error {
+	apiPath := fmt.Sprintf("%s%s", API_VERSION, path)
+	logger := client.Logger.WithFields(log.Fields{
+		"path":   apiPath,
+		"method": method,
+	})
+	url := fmt.Sprintf("%s/%s", client.Url, apiPath)
+
+	logger.WithField("params", string(cbor)).Debug("sending request")
+
+	var request *http.Request
+	var err error
+	if len(cbor) > 0 {
+		payload, err := json.Marshal(cbor)
+		if err != nil {
+			return fmt.Errorf("failed to encode request body: %w", err)
+		}
+		request, err = http.NewRequest(method, url, bytes.NewBuffer(payload))
+		request.Header.Set("Content-Type", "application/cbor")
+	} else {
+		request, err = http.NewRequest(method, url, nil)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	if client.ProjectId != "" {
+		request.Header.Set("project_id", client.ProjectId)
+	}
+
+	response, err := client.HttpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer response.Body.Close()
+
+	buff, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to send request, status: %s, error: %s", response.Status, buff)
+	}
+
+	logger.WithFields(log.Fields{
+		"responseBody": string(buff),
+		"status":       response.Status,
+		"code":         response.StatusCode,
+	}).Debug("got response")
+
+	if len(buff) == 0 {
+		return nil
+	}
+
+	err = json.Unmarshal(buff, resp)
+	if err != nil {
+		return fmt.Errorf("failed to decode response body: %w, buff: %s", err, string(buff))
+	}
+
+	return nil
+}

--- a/chain/cardano/client/client_test.go
+++ b/chain/cardano/client/client_test.go
@@ -399,11 +399,13 @@ func TestFetchTxInfo(t *testing.T) {
 }
 
 func MustParseTime(s string) time.Time {
-	time, err := time.Parse(time.RFC3339, s)
+	t, err := time.Parse(time.RFC3339, s)
 	if err != nil {
 		panic("failed to parse time")
 	}
-	return time
+
+	unixTime := t.Unix()
+	return time.Unix(unixTime, 0)
 }
 
 func NewMovement(

--- a/chain/cardano/client/client_test.go
+++ b/chain/cardano/client/client_test.go
@@ -1,0 +1,43 @@
+package client_test
+
+import (
+	"context"
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/chain/template/client"
+	"github.com/cordialsys/crosschain/chain/template/tx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+
+	client, err := client.NewClient(xc.NewChainConfig(""))
+	require.NotNil(t, client)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestFetchTxInput(t *testing.T) {
+
+	client, _ := client.NewClient(xc.NewChainConfig(""))
+	from := xc.Address("from")
+	to := xc.Address("to")
+	input, err := client.FetchLegacyTxInput(context.Background(), from, to)
+	require.NotNil(t, input)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestSubmitTx(t *testing.T) {
+
+	client, _ := client.NewClient(xc.NewChainConfig(""))
+	err := client.SubmitTx(context.Background(), &tx.Tx{})
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestFetchTxInfo(t *testing.T) {
+
+	client, _ := client.NewClient(xc.NewChainConfig(""))
+	info, err := client.FetchLegacyTxInfo(context.Background(), xc.TxHash("hash"))
+	require.NotNil(t, info)
+	require.EqualError(t, err, "not implemented")
+}

--- a/chain/cardano/client/client_test.go
+++ b/chain/cardano/client/client_test.go
@@ -19,10 +19,16 @@ import (
 )
 
 func NewTestConfig() *xc.ChainConfig {
+	amount, err := xc.NewAmountHumanReadableFromStr("3.0")
+	if err != nil {
+		panic(err)
+	}
 	return xc.NewChainConfig(xc.ADA).
 		WithNet("preprod").
 		WithDecimals(6).
-		WithUrl("https://mainnet.cardano.org")
+		WithUrl("https://mainnet.cardano.org").
+		WithTransactionActiveTime(time.Hour * 2).
+		WithGasBudgetDefault(amount)
 }
 
 func TestNewClient(t *testing.T) {
@@ -124,11 +130,9 @@ func TestFetchTxInput(t *testing.T) {
 						Index:  1,
 					},
 				},
-				Slot:             90_751_416,
-				FixedFee:         xc.NewAmountBlockchainFromUint64(155_381),
-				FeePerByte:       xc.NewAmountBlockchainFromUint64(44),
-				MinUtxo:          xc.NewAmountBlockchainFromUint64(4_310),
-				CoinsPerUtxoWord: xc.NewAmountBlockchainFromUint64(4_310),
+				Slot:                    90_751_416,
+				Fee:                     166265,
+				TransactionValidityTime: 7200,
 			},
 			err: false,
 		},
@@ -157,7 +161,11 @@ func TestFetchTxInput(t *testing.T) {
 			client, _ := client.NewClient(cfg)
 			client.Url = server.URL
 
-			args, err := xcbuilder.NewTransferArgs(xc.Address(""), xc.Address(""), xc.NewAmountBlockchainFromUint64(1_000_000))
+			args, err := xcbuilder.NewTransferArgs(
+				xc.Address("addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5"),
+				xc.Address("addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5"),
+				xc.NewAmountBlockchainFromUint64(1_000_000),
+			)
 			input, err := client.FetchTransferInput(context.Background(), args)
 			if vector.err {
 				require.Error(t, err)

--- a/chain/cardano/client/client_test.go
+++ b/chain/cardano/client/client_test.go
@@ -2,42 +2,420 @@ package client_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	xc "github.com/cordialsys/crosschain"
-	"github.com/cordialsys/crosschain/chain/template/client"
-	"github.com/cordialsys/crosschain/chain/template/tx"
+	xcbuilder "github.com/cordialsys/crosschain/builder"
+	"github.com/cordialsys/crosschain/chain/cardano/client"
+	"github.com/cordialsys/crosschain/chain/cardano/client/types"
+	"github.com/cordialsys/crosschain/chain/cardano/tx"
+	"github.com/cordialsys/crosschain/chain/cardano/tx_input"
+	xclient "github.com/cordialsys/crosschain/client"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewClient(t *testing.T) {
+func NewTestConfig() *xc.ChainConfig {
+	return xc.NewChainConfig(xc.ADA).
+		WithNet("preprod").
+		WithDecimals(6).
+		WithUrl("https://mainnet.cardano.org")
+}
 
-	client, err := client.NewClient(xc.NewChainConfig(""))
-	require.NotNil(t, client)
-	require.EqualError(t, err, "not implemented")
+func TestNewClient(t *testing.T) {
+	vectors := []struct {
+		testName       string
+		url            string
+		network        string
+		expectedClient *client.Client
+		err            string
+	}{
+		{
+			testName: "MainnetClient",
+			url:      "https://mainnet.cardano.org",
+			network:  "mainnet",
+			expectedClient: &client.Client{
+				Url:     "https://mainnet.cardano.org",
+				Network: "mainnet",
+			},
+		},
+		{
+			testName: "ImplicitMainnetClient",
+			url:      "https://mainnet.cardano.org",
+			network:  "",
+			expectedClient: &client.Client{
+				Url:     "https://mainnet.cardano.org",
+				Network: "mainnet",
+			},
+		},
+		{
+			testName: "MissingUrl",
+			url:      "",
+			network:  "mainnet",
+			expectedClient: &client.Client{
+				Url:     "https://mainnet.cardano.org",
+				Network: "mainnet",
+			},
+			err: "rpc url is empty",
+		},
+	}
+
+	for _, vector := range vectors {
+		t.Run(vector.testName, func(t *testing.T) {
+			client, err := client.NewClient(xc.NewChainConfig(xc.ADA).WithUrl(vector.url).WithNet(vector.network))
+			if vector.err != "" {
+				require.EqualError(t, err, vector.err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, vector.expectedClient.Url, client.Url)
+			require.Equal(t, vector.expectedClient.Network, client.Network)
+		})
+	}
+
 }
 
 func TestFetchTxInput(t *testing.T) {
+	vectors := []struct {
+		name                       string
+		addressUtxosResponse       string
+		latestBlockResponse        string
+		protocolParametersResponse string
+		expectedInput              *tx_input.TxInput
+		err                        bool
+	}{
+		{
+			name:          "NoReplies",
+			expectedInput: nil,
+			err:           true,
+		},
+		{
+			name:                 "NoLatestBlockResponse",
+			addressUtxosResponse: `[{"address":"addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5","tx_hash":"72cfa181469b48402a50c6652d45c789897ae5025bb01f569a7bd01bffd12bc1","tx_index":1,"output_index":1,"amount":[{"unit":"lovelace","quantity":"5333004"}],"block":"babb05fe6f3128a398dfce79ad1f836a0031bd6d84969755ce7a043b0c604cec","data_hash":null,"inline_datum":null,"reference_script_hash":null}]`,
+			expectedInput:        nil,
+			err:                  true,
+		},
+		{
+			name:                 "NoProtocolParametersResponse",
+			addressUtxosResponse: `[{"address":"addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5","tx_hash":"72cfa181469b48402a50c6652d45c789897ae5025bb01f569a7bd01bffd12bc1","tx_index":1,"output_index":1,"amount":[{"unit":"lovelace","quantity":"5333004"}],"block":"babb05fe6f3128a398dfce79ad1f836a0031bd6d84969755ce7a043b0c604cec","data_hash":null,"inline_datum":null,"reference_script_hash":null}]`,
+			latestBlockResponse:  `{"time":1746434616,"height":3446505,"hash":"a13ea6bdb4f23caa803274011c0524e4d96eb7cacb4103998d508c257361cd1b","slot":90751416,"epoch":213,"epoch_slot":377016,"slot_leader":"pool1rccstu3l9ty3k0a5cd06fl3szsss9r34dcg5j38fqgq9kvng0tg","size":4,"tx_count":0,"output":null,"fees":null,"block_vrf":"vrf_vk1kkc5ar4jt2fkdcxp5sa0ekxsskfyjgp082xuqwcn7stvwr2dultsuwejcz","op_cert":"bb4f8eb8a07ca955b55a2c917df0475ccc36cf5487e1af0f97f562717d59ba82","op_cert_counter":"7","previous_block":"babb05fe6f3128a398dfce79ad1f836a0031bd6d84969755ce7a043b0c604cec","next_block":null,"confirmations":0}`,
+			expectedInput:        nil,
+			err:                  true,
+		},
+		{
+			name:                       "ValidInput",
+			addressUtxosResponse:       `[{"address":"addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5","tx_hash":"72cfa181469b48402a50c6652d45c789897ae5025bb01f569a7bd01bffd12bc1","tx_index":1,"output_index":1,"amount":[{"unit":"lovelace","quantity":"5333004"}],"block":"babb05fe6f3128a398dfce79ad1f836a0031bd6d84969755ce7a043b0c604cec","data_hash":null,"inline_datum":null,"reference_script_hash":null}]`,
+			latestBlockResponse:        `{"time":1746434616,"height":3446505,"hash":"a13ea6bdb4f23caa803274011c0524e4d96eb7cacb4103998d508c257361cd1b","slot":90751416,"epoch":213,"epoch_slot":377016,"slot_leader":"pool1rccstu3l9ty3k0a5cd06fl3szsss9r34dcg5j38fqgq9kvng0tg","size":4,"tx_count":0,"output":null,"fees":null,"block_vrf":"vrf_vk1kkc5ar4jt2fkdcxp5sa0ekxsskfyjgp082xuqwcn7stvwr2dultsuwejcz","op_cert":"bb4f8eb8a07ca955b55a2c917df0475ccc36cf5487e1af0f97f562717d59ba82","op_cert_counter":"7","previous_block":"babb05fe6f3128a398dfce79ad1f836a0031bd6d84969755ce7a043b0c604cec","next_block":null,"confirmations":0}`,
+			protocolParametersResponse: `{"min_fee_a":44,"min_fee_b":155381,"min_utxo":"4310", "coins_per_utxo_word":"4310"}`,
+			expectedInput: &tx_input.TxInput{
+				Utxos: []types.Utxo{
+					{
+						Address: "addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5",
+						Amounts: []types.Amount{
+							{
+								Unit:     "lovelace",
+								Quantity: "5333004",
+							},
+						},
+						TxHash: "72cfa181469b48402a50c6652d45c789897ae5025bb01f569a7bd01bffd12bc1",
+						Index:  1,
+					},
+				},
+				Slot:             90_751_416,
+				FixedFee:         xc.NewAmountBlockchainFromUint64(155_381),
+				FeePerByte:       xc.NewAmountBlockchainFromUint64(44),
+				MinUtxo:          xc.NewAmountBlockchainFromUint64(4_310),
+				CoinsPerUtxoWord: xc.NewAmountBlockchainFromUint64(4_310),
+			},
+			err: false,
+		},
+	}
 
-	client, _ := client.NewClient(xc.NewChainConfig(""))
-	from := xc.Address("from")
-	to := xc.Address("to")
-	input, err := client.FetchLegacyTxInput(context.Background(), from, to)
-	require.NotNil(t, input)
-	require.EqualError(t, err, "not implemented")
+	cfg := NewTestConfig()
+	for _, vector := range vectors {
+		t.Run(vector.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				url := r.URL
+				if vector.err {
+					w.WriteHeader(http.StatusBadRequest)
+				} else {
+					w.WriteHeader(http.StatusOK)
+				}
+				if strings.Contains(url.Path, "utxo") {
+					w.Write([]byte(vector.addressUtxosResponse))
+				} else if strings.Contains(url.Path, "block") {
+					w.Write([]byte(vector.latestBlockResponse))
+				} else {
+					w.Write([]byte(vector.protocolParametersResponse))
+				}
+			}))
+			defer server.Close()
+
+			client, _ := client.NewClient(cfg)
+			client.Url = server.URL
+
+			args, err := xcbuilder.NewTransferArgs(xc.Address(""), xc.Address(""), xc.NewAmountBlockchainFromUint64(1_000_000))
+			input, err := client.FetchTransferInput(context.Background(), args)
+			if vector.err {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, vector.expectedInput, input)
+		})
+	}
 }
 
 func TestSubmitTx(t *testing.T) {
+	vectors := []struct {
+		name                       string
+		addressUtxosResponse       string
+		latestBlockResponse        string
+		protocolParametersResponse string
+		submitSuccess              bool
+		err                        bool
+	}{
+		{
+			name:                       "FailedSubmit",
+			addressUtxosResponse:       `[{"address":"addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5","tx_hash":"72cfa181469b48402a50c6652d45c789897ae5025bb01f569a7bd01bffd12bc1","tx_index":1,"output_index":1,"amount":[{"unit":"lovelace","quantity":"5333004"}],"block":"babb05fe6f3128a398dfce79ad1f836a0031bd6d84969755ce7a043b0c604cec","data_hash":null,"inline_datum":null,"reference_script_hash":null}]`,
+			latestBlockResponse:        `{"time":1746434616,"height":3446505,"hash":"a13ea6bdb4f23caa803274011c0524e4d96eb7cacb4103998d508c257361cd1b","slot":90751416,"epoch":213,"epoch_slot":377016,"slot_leader":"pool1rccstu3l9ty3k0a5cd06fl3szsss9r34dcg5j38fqgq9kvng0tg","size":4,"tx_count":0,"output":null,"fees":null,"block_vrf":"vrf_vk1kkc5ar4jt2fkdcxp5sa0ekxsskfyjgp082xuqwcn7stvwr2dultsuwejcz","op_cert":"bb4f8eb8a07ca955b55a2c917df0475ccc36cf5487e1af0f97f562717d59ba82","op_cert_counter":"7","previous_block":"babb05fe6f3128a398dfce79ad1f836a0031bd6d84969755ce7a043b0c604cec","next_block":null,"confirmations":0}`,
+			protocolParametersResponse: `{"min_fee_a":44,"min_fee_b":155381,"min_utxo":"4310", "coins_per_utxo_word":"4310"}`,
+			submitSuccess:              false,
+			err:                        true,
+		},
+		{
+			name:                       "Success",
+			addressUtxosResponse:       `[{"address":"addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5","tx_hash":"72cfa181469b48402a50c6652d45c789897ae5025bb01f569a7bd01bffd12bc1","tx_index":1,"output_index":1,"amount":[{"unit":"lovelace","quantity":"5333004"}],"block":"babb05fe6f3128a398dfce79ad1f836a0031bd6d84969755ce7a043b0c604cec","data_hash":null,"inline_datum":null,"reference_script_hash":null}]`,
+			latestBlockResponse:        `{"time":1746434616,"height":3446505,"hash":"a13ea6bdb4f23caa803274011c0524e4d96eb7cacb4103998d508c257361cd1b","slot":90751416,"epoch":213,"epoch_slot":377016,"slot_leader":"pool1rccstu3l9ty3k0a5cd06fl3szsss9r34dcg5j38fqgq9kvng0tg","size":4,"tx_count":0,"output":null,"fees":null,"block_vrf":"vrf_vk1kkc5ar4jt2fkdcxp5sa0ekxsskfyjgp082xuqwcn7stvwr2dultsuwejcz","op_cert":"bb4f8eb8a07ca955b55a2c917df0475ccc36cf5487e1af0f97f562717d59ba82","op_cert_counter":"7","previous_block":"babb05fe6f3128a398dfce79ad1f836a0031bd6d84969755ce7a043b0c604cec","next_block":null,"confirmations":0}`,
+			protocolParametersResponse: `{"min_fee_a":44,"min_fee_b":155381,"min_utxo":"4310", "coins_per_utxo_word":"4310"}`,
+			submitSuccess:              true,
+			err:                        false,
+		},
+	}
 
-	client, _ := client.NewClient(xc.NewChainConfig(""))
-	err := client.SubmitTx(context.Background(), &tx.Tx{})
-	require.EqualError(t, err, "not implemented")
+	cfg := NewTestConfig()
+	for _, vector := range vectors {
+		t.Run(vector.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				url := r.URL
+				if strings.Contains(url.Path, "utxo") {
+					w.Write([]byte(vector.addressUtxosResponse))
+				} else if strings.Contains(url.Path, "block") {
+					w.Write([]byte(vector.latestBlockResponse))
+				} else if strings.Contains(url.Path, "submit") {
+					if vector.submitSuccess {
+						w.WriteHeader(http.StatusOK)
+					} else {
+						w.WriteHeader(http.StatusBadRequest)
+					}
+				} else {
+					w.Write([]byte(vector.protocolParametersResponse))
+				}
+			}))
+			defer server.Close()
+
+			client, _ := client.NewClient(cfg)
+			client.Url = server.URL
+
+			args, err := xcbuilder.NewTransferArgs(
+				xc.Address("addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5"),
+				xc.Address("addr_test1qrfp5xelv2mu7k8zyvwm0c8t5xm55wanwhtd4fgjgtf3ck0rplhn7x9jyhwqg70fwv0ujpmyumqk5td9e9hnsejtlxnq3yqf25"),
+				xc.NewAmountBlockchainFromUint64(1_000_000),
+			)
+			input, err := client.FetchTransferInput(context.Background(), args)
+			require.NoError(t, err)
+			require.NotNil(t, input)
+
+			tx, err := tx.NewTx(args, *input.(*tx_input.TxInput))
+			require.NoError(t, err)
+
+			err = client.SubmitTx(context.Background(), tx)
+			if vector.err {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestFetchTxInfo(t *testing.T) {
+	vectors := []struct {
+		name                   string
+		getLatestBlockResponse string
+		getTxInfoResponse      string
+		getBlockInfo           string
+		getTxUtxos             string
+		expectedInfo           xclient.TxInfo
+	}{
+		{
+			name:                   "ValidResponse",
+			getLatestBlockResponse: `{"time":1746445795,"height":3446919,"hash":"9d5440776dd6432ae89db73241ff35b2d603ad48e040f5ea9897df3f3251cb6d","slot":90762595,"epoch":213,"epoch_slot":388195,"slot_leader":"pool1z05xqzuxnpl8kg8u2wwg8ftng0fwtdluv3h20ruryfqc5gc3efl","size":4,"tx_count":0,"output":null,"fees":null,"block_vrf":"vrf_vk1n9jgutq5vr79dhftlzwvmppa8myt4x94u3znhylud7vc0wts0g4q9v68z8","op_cert":"de399288bef696641b7bbb25ffd9ee476e4facb2aa3f2f66e4cb01cd2964537c","op_cert_counter":"12","previous_block":"a407a024a531936330b069d764748ef48521dd495242636f56df322815b510fd","next_block":null,"confirmations":0}`,
+			getTxInfoResponse:      `{"hash":"3b28dc6d6cc32280a2738799a6b5defc96b66999a17481a7cdaa27e8c00bd610","block":"fc83ca908ded9ae5043276fcc54ea7438d0d2b02a429e80ce48aca57c2d08623","block_height":3436192,"block_time":1746168211,"slot":90485011,"index":0,"output_amount":[{"unit":"lovelace","quantity":"19758792833"},{"unit":"2682a9b99553406c39f693bb450d6001954e3504c96238c6b96ad79a476c6f62616c20456e7465727461696e6d656e7420546f6b656e202847455429","quantity":"210000"},{"unit":"2682a9b99553406c39f693bb450d6001954e3504c96238c6b96ad79a476c6f62616c20456e7465727461696e6d656e7420546f6b656e202847455429","quantity":"194249999"},{"unit":"553cbd1862bfb5ff69b6ebdcbb6165beb47171a04b841c79c72e75a94745542d415554482d544b4e","quantity":"1"}],"fees":"1402193","deposit":"0","size":13268,"invalid_before":null,"invalid_hereafter":null,"utxo_count":4,"withdrawal_count":0,"mir_cert_count":0,"delegation_count":0,"stake_cert_count":0,"pool_update_count":0,"pool_retire_count":0,"asset_mint_or_burn_count":0,"redeemer_count":1,"valid_contract":true}`,
+			getBlockInfo:           `{"time":1746168211,"height":3436192,"hash":"fc83ca908ded9ae5043276fcc54ea7438d0d2b02a429e80ce48aca57c2d08623","slot":90485011,"epoch":213,"epoch_slot":110611,"slot_leader":"pool1ytvs2jlrtftapsgdhtlm8ch0xa2d3e3lsnf59jz68mtk5pml699","size":13272,"tx_count":1,"output":"19758792833","fees":"1402193","block_vrf":"vrf_vk1cham4jns9uc5rg0yk7fufpyc2pcz67tnhyh96g48l2u00skkmrlqnp8xmp","op_cert":"fa27bd7afb410ac7d9e16d6da1a4b487305424289336d0a0035f52bb3b3830c8","op_cert_counter":"2","previous_block":"8b58c40edccfbe2b852ed75e4c4f680da383fcc3298a177db84d80ba78a5b94b","next_block":"962e871831aa0fcdbb457bcf147a553df4ab87d32a7fcfd09901cd2a331d750f","confirmations":10727}`,
+			getTxUtxos:             `{"hash":"3b28dc6d6cc32280a2738799a6b5defc96b66999a17481a7cdaa27e8c00bd610","inputs":[{"address":"addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283","amount":[{"unit":"lovelace","quantity":"1796623"},{"unit":"2682a9b99553406c39f693bb450d6001954e3504c96238c6b96ad79a476c6f62616c20456e7465727461696e6d656e7420546f6b656e202847455429","quantity":"10000"},{"unit":"553cbd1862bfb5ff69b6ebdcbb6165beb47171a04b841c79c72e75a94745542d415554482d544b4e","quantity":"1"}],"tx_hash":"bcda48666026306d1b958256cb94ad4cef0fe14d1dc44165b25947642e1eae1e","output_index":0,"data_hash":"2d9bfbb2e1b6e1af2f55f268a3ad8281f218661fd38c66abf91ed8d9f69a3cf7","inline_datum":"d8799f43474554192710192710581c2682a9b99553406c39f693bb450d6001954e3504c96238c6b96ad79a5820476c6f62616c20456e7465727461696e6d656e7420546f6b656e202847455429ff","reference_script_hash":null,"collateral":false,"reference":false},{"address":"addr_test1qzyf6t5qq037n0srm4r84w3hchgvmgu45ks9pf5f27qhnykxp572eea783cccv2fmpqs5s6va4n7pusy097meenje88s6p7x42","amount":[{"unit":"lovelace","quantity":"19758398403"},{"unit":"2682a9b99553406c39f693bb450d6001954e3504c96238c6b96ad79a476c6f62616c20456e7465727461696e6d656e7420546f6b656e202847455429","quantity":"194449999"}],"tx_hash":"bcda48666026306d1b958256cb94ad4cef0fe14d1dc44165b25947642e1eae1e","output_index":1,"data_hash":null,"inline_datum":null,"reference_script_hash":null,"collateral":false,"reference":false},{"address":"addr_test1qqdqfz660junmjs96qxyh760e9h6zme5jrvectx4tznhk8q72rs5hptlwsvhwphrfrkuyftnxwv6ld2r8yag3gmaz82sx05amf","amount":[{"unit":"lovelace","quantity":"489053618"}],"tx_hash":"6cda8edb61295ddd017ec83f330f049e0704a622b78484a3361865e12837fbd3","output_index":3,"data_hash":null,"inline_datum":null,"reference_script_hash":null,"collateral":true,"reference":false}],"outputs":[{"address":"addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283","amount":[{"unit":"lovelace","quantity":"1796623"},{"unit":"2682a9b99553406c39f693bb450d6001954e3504c96238c6b96ad79a476c6f62616c20456e7465727461696e6d656e7420546f6b656e202847455429","quantity":"210000"},{"unit":"553cbd1862bfb5ff69b6ebdcbb6165beb47171a04b841c79c72e75a94745542d415554482d544b4e","quantity":"1"}],"output_index":0,"data_hash":"db96855ad4f7d869a68d8b236dd2c80ef6c810fa34ee150150d3274aef4250ce","inline_datum":"d8799f434745541a000334501a00033450581c2682a9b99553406c39f693bb450d6001954e3504c96238c6b96ad79a5820476c6f62616c20456e7465727461696e6d656e7420546f6b656e202847455429ff","collateral":false,"reference_script_hash":null,"consumed_by_tx":"b32a89380c217f3aede4b95d5acc7cd9d5e704d4f3fb924b9ffa6b3558494978"},{"address":"addr_test1qzyf6t5qq037n0srm4r84w3hchgvmgu45ks9pf5f27qhnykxp572eea783cccv2fmpqs5s6va4n7pusy097meenje88s6p7x42","amount":[{"unit":"lovelace","quantity":"19756996210"},{"unit":"2682a9b99553406c39f693bb450d6001954e3504c96238c6b96ad79a476c6f62616c20456e7465727461696e6d656e7420546f6b656e202847455429","quantity":"194249999"}],"output_index":1,"data_hash":null,"inline_datum":null,"collateral":false,"reference_script_hash":null,"consumed_by_tx":"b32a89380c217f3aede4b95d5acc7cd9d5e704d4f3fb924b9ffa6b3558494978"}]}`,
+			expectedInfo: xclient.TxInfo{
+				Name:   "chains/ADA/transactions/3b28dc6d6cc32280a2738799a6b5defc96b66999a17481a7cdaa27e8c00bd610",
+				Hash:   "3b28dc6d6cc32280a2738799a6b5defc96b66999a17481a7cdaa27e8c00bd610",
+				XChain: "ADA",
+				State:  "succeeded",
+				Final:  true,
+				Block: &xclient.Block{
+					Chain:  "ADA",
+					Height: xc.NewAmountBlockchainFromUint64(3_436_192),
+					Hash:   "fc83ca908ded9ae5043276fcc54ea7438d0d2b02a429e80ce48aca57c2d08623",
+					Time:   MustParseTime("2025-05-02T08:43:31+02:00"),
+				},
+				Movements: []*xclient.Movement{
+					NewMovement(
+						"ADA",
+						"ADA",
+						[]*xclient.BalanceChange{
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(1_796_623),
+								XAddress:  "chains/ADA/addresses/addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283",
+								AddressId: "addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283",
+							},
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(19_758_398_403),
+								XAddress:  "chains/ADA/addresses/addr_test1qzyf6t5qq037n0srm4r84w3hchgvmgu45ks9pf5f27qhnykxp572eea783cccv2fmpqs5s6va4n7pusy097meenje88s6p7x42",
+								AddressId: "addr_test1qzyf6t5qq037n0srm4r84w3hchgvmgu45ks9pf5f27qhnykxp572eea783cccv2fmpqs5s6va4n7pusy097meenje88s6p7x42",
+							},
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(489_053_618),
+								XAddress:  "chains/ADA/addresses/addr_test1qqdqfz660junmjs96qxyh760e9h6zme5jrvectx4tznhk8q72rs5hptlwsvhwphrfrkuyftnxwv6ld2r8yag3gmaz82sx05amf",
+								AddressId: "addr_test1qqdqfz660junmjs96qxyh760e9h6zme5jrvectx4tznhk8q72rs5hptlwsvhwphrfrkuyftnxwv6ld2r8yag3gmaz82sx05amf",
+							},
+						},
+						[]*xclient.BalanceChange{
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(1_796_623),
+								XAddress:  "chains/ADA/addresses/addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283",
+								AddressId: "addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283",
+							},
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(19_756_996_210),
+								XAddress:  "chains/ADA/addresses/addr_test1qzyf6t5qq037n0srm4r84w3hchgvmgu45ks9pf5f27qhnykxp572eea783cccv2fmpqs5s6va4n7pusy097meenje88s6p7x42",
+								AddressId: "addr_test1qzyf6t5qq037n0srm4r84w3hchgvmgu45ks9pf5f27qhnykxp572eea783cccv2fmpqs5s6va4n7pusy097meenje88s6p7x42",
+							},
+						},
+						nil,
+					),
+					NewMovement(
+						"ADA",
+						"2682a9b99553406c39f693bb450d6001954e3504c96238c6b96ad79a476c6f62616c20456e7465727461696e6d656e7420546f6b656e202847455429",
+						[]*xclient.BalanceChange{
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(10_000),
+								XAddress:  "chains/ADA/addresses/addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283",
+								AddressId: "addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283",
+							},
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(194_449_999),
+								XAddress:  "chains/ADA/addresses/addr_test1qzyf6t5qq037n0srm4r84w3hchgvmgu45ks9pf5f27qhnykxp572eea783cccv2fmpqs5s6va4n7pusy097meenje88s6p7x42",
+								AddressId: "addr_test1qzyf6t5qq037n0srm4r84w3hchgvmgu45ks9pf5f27qhnykxp572eea783cccv2fmpqs5s6va4n7pusy097meenje88s6p7x42",
+							},
+						},
+						[]*xclient.BalanceChange{
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(210_000),
+								XAddress:  "chains/ADA/addresses/addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283",
+								AddressId: "addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283",
+							},
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(194_249_999),
+								XAddress:  "chains/ADA/addresses/addr_test1qzyf6t5qq037n0srm4r84w3hchgvmgu45ks9pf5f27qhnykxp572eea783cccv2fmpqs5s6va4n7pusy097meenje88s6p7x42",
+								AddressId: "addr_test1qzyf6t5qq037n0srm4r84w3hchgvmgu45ks9pf5f27qhnykxp572eea783cccv2fmpqs5s6va4n7pusy097meenje88s6p7x42",
+							},
+						},
+						nil,
+					),
+					NewMovement(
+						"ADA",
+						"553cbd1862bfb5ff69b6ebdcbb6165beb47171a04b841c79c72e75a94745542d415554482d544b4e",
+						[]*xclient.BalanceChange{
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(1),
+								XAddress:  "chains/ADA/addresses/addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283",
+								AddressId: "addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283",
+							},
+						},
+						[]*xclient.BalanceChange{
+							{
+								Balance:   xc.NewAmountBlockchainFromUint64(1),
+								XAddress:  "chains/ADA/addresses/addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283",
+								AddressId: "addr_test1wr54sl5p9yuvaknwv8kjyg7k7n6h02rccyh7s7ntuqs49rsfy5283",
+							},
+						},
+						nil,
+					),
+				},
+				Fees: []*xclient.Balance{
+					{
+						Asset:    "chains/ADA/assets/ADA",
+						Contract: "ADA",
+						Balance:  xc.NewAmountBlockchainFromUint64(1_402_193),
+					},
+				},
+				Stakes:        nil,
+				Unstakes:      nil,
+				Confirmations: 10727,
+				Error:         nil,
+			},
+		},
+	}
 
-	client, _ := client.NewClient(xc.NewChainConfig(""))
-	info, err := client.FetchLegacyTxInfo(context.Background(), xc.TxHash("hash"))
-	require.NotNil(t, info)
-	require.EqualError(t, err, "not implemented")
+	for _, vector := range vectors {
+		t.Run(vector.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				url := r.URL
+				if strings.Contains(url.Path, "blocks/latest") {
+					w.Write([]byte(vector.getLatestBlockResponse))
+				} else if strings.Contains(url.Path, "utxos") {
+					w.Write([]byte(vector.getTxUtxos))
+				} else if strings.Contains(url.Path, "txs") {
+					w.Write([]byte(vector.getTxInfoResponse))
+				} else if strings.Contains(url.Path, "blocks") {
+					w.Write([]byte(vector.getBlockInfo))
+				}
+			}))
+			defer server.Close()
+
+			cfg := NewTestConfig()
+			client, _ := client.NewClient(cfg)
+			client.Url = server.URL
+
+			txInfo, err := client.FetchTxInfo(context.Background(), "3b28dc6d6cc32280a2738799a6b5defc96b66999a17481a7cdaa27e8c00bd610")
+			require.NoError(t, err)
+			require.Equal(t, vector.expectedInfo, txInfo)
+		})
+	}
+
+}
+
+func MustParseTime(s string) time.Time {
+	time, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic("failed to parse time")
+	}
+	return time
+}
+
+func NewMovement(
+	chain string,
+	contract string,
+	from []*xclient.BalanceChange,
+	to []*xclient.BalanceChange,
+	event *xclient.Event,
+) *xclient.Movement {
+	movement := xclient.NewMovement(xc.NativeAsset(chain), xc.ContractAddress(contract))
+	movement.From = from
+	movement.To = to
+	movement.Event = event
+	return movement
 }

--- a/chain/cardano/client/types/blockfrost.go
+++ b/chain/cardano/client/types/blockfrost.go
@@ -1,10 +1,36 @@
 package types
 
 import (
+	"fmt"
+
 	xc "github.com/cordialsys/crosschain"
 )
 
-const Cardano = "cardano"
+const (
+	Cardano = "cardano"
+	// Cardano uses lovelace as the smallest unit of ada
+	// 1 lovelace = 0.000001 ada
+	Lovelace                      = "lovelace"
+	Ada                           = "ADA"
+	CodeRequestNotValid           = "400"
+	CodeDailyRequestLimitExceeded = "402"
+	CodeNotAuthenticated          = "403"
+	CodeResourceDoesNotExist      = "404"
+	CodeUserAutoBannedForFlooding = "418"
+	CodeMempoolFull               = "425"
+	CodeRateLimitExceeded         = "429"
+	CodeInternalServerError       = "500"
+)
+
+type Error struct {
+	StatusCode int    `json:"status_code,omitempty"`
+	Err        string `json:"error,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("StatusCode: %d, Error: %s, Message: %s", e.StatusCode, e.Err, e.Message)
+}
 
 type Amount struct {
 	Unit     string `json:"unit"`

--- a/chain/cardano/client/types/blockfrost.go
+++ b/chain/cardano/client/types/blockfrost.go
@@ -1,0 +1,62 @@
+package types
+
+import (
+	xc "github.com/cordialsys/crosschain"
+)
+
+const Cardano = "cardano"
+
+type Amount struct {
+	Unit     string `json:"unit"`
+	Quantity string `json:"quantity"`
+}
+
+type GetAddressInfoResponse struct {
+	Address string   `json:"address"`
+	Amounts []Amount `json:"amount"`
+}
+
+type Block struct {
+	Time          int64  `json:"time"`
+	Height        uint64 `json:"height"`
+	Hash          string `json:"hash"`
+	Slot          uint64 `json:"slot"`
+	Confirmations uint64 `json:"confirmations"`
+}
+
+type TransactionInfo struct {
+	Hash        string `json:"hash"`
+	Block       string `json:"block"`
+	BlockHeight uint64 `json:"block_height"`
+	BlockTime   uint64 `json:"block_time"`
+	Fees        string `json:"fees"`
+}
+
+type ProtocolParameters struct {
+	FeePerByte       uint64 `json:"min_fee_a"`
+	FixedFee         uint64 `json:"min_fee_b"`
+	MinUtxoValue     string `json:"min_utxo"`
+	CoinsPerUtxoWord string `json:"coins_per_utxo_word"`
+}
+
+type Utxo struct {
+	Address string   `json:"address"`
+	Amounts []Amount `json:"amount"`
+	TxHash  string   `json:"tx_hash"`
+	Index   uint16   `json:"index"`
+}
+
+func (u *Utxo) GetAssetAmount(contract xc.ContractAddress) xc.AmountBlockchain {
+	for _, amount := range u.Amounts {
+		if amount.Unit == string(contract) {
+			return xc.NewAmountBlockchainFromStr(amount.Quantity)
+		}
+	}
+
+	return xc.NewAmountBlockchainFromUint64(0)
+}
+
+type TransactionUtxos struct {
+	Inputs  []Utxo `json:"inputs"`
+	Outputs []Utxo `json:"outputs"`
+}

--- a/chain/cardano/client/types/blockfrost.go
+++ b/chain/cardano/client/types/blockfrost.go
@@ -43,7 +43,7 @@ type Utxo struct {
 	Address string   `json:"address"`
 	Amounts []Amount `json:"amount"`
 	TxHash  string   `json:"tx_hash"`
-	Index   uint16   `json:"index"`
+	Index   uint16   `json:"output_index"`
 }
 
 func (u *Utxo) GetAssetAmount(contract xc.ContractAddress) xc.AmountBlockchain {

--- a/chain/cardano/errors.go
+++ b/chain/cardano/errors.go
@@ -1,7 +1,30 @@
 package newchain
 
-import "github.com/cordialsys/crosschain/client/errors"
+import (
+	"strings"
+
+	"github.com/cordialsys/crosschain/chain/cardano/client/types"
+	"github.com/cordialsys/crosschain/client/errors"
+)
 
 func CheckError(err error) errors.Status {
-	return ""
+	if strings.Contains(err.Error(), types.CodeMempoolFull) {
+		return errors.NetworkError
+	}
+	if strings.Contains(err.Error(), types.CodeDailyRequestLimitExceeded) {
+		return errors.NetworkError
+	}
+	if strings.Contains(err.Error(), types.CodeInternalServerError) {
+		return errors.NetworkError
+	}
+	if strings.Contains(err.Error(), types.CodeNotAuthenticated) {
+		return errors.NetworkError
+	}
+	if strings.Contains(err.Error(), types.CodeRateLimitExceeded) {
+		return errors.NetworkError
+	}
+	if strings.Contains(err.Error(), types.CodeUserAutoBannedForFlooding) {
+		return errors.NetworkError
+	}
+	return errors.UnknownError
 }

--- a/chain/cardano/errors.go
+++ b/chain/cardano/errors.go
@@ -8,6 +8,14 @@ import (
 )
 
 func CheckError(err error) errors.Status {
+	if strings.Contains(err.Error(), types.CodeRequestNotValid) {
+		if strings.Contains(err.Error(), "invalidBefore = SNothing, invalidHereafter = SJust") {
+			return errors.TransactionTimedOut
+		}
+		if strings.Contains(err.Error(), "MissingVKeyWitnessesUTXOW") {
+			return errors.TransactionFailure
+		}
+	}
 	if strings.Contains(err.Error(), types.CodeMempoolFull) {
 		return errors.NetworkError
 	}
@@ -26,5 +34,9 @@ func CheckError(err error) errors.Status {
 	if strings.Contains(err.Error(), types.CodeUserAutoBannedForFlooding) {
 		return errors.NetworkError
 	}
+	if strings.Contains(err.Error(), "negative change amount for contract") {
+		return errors.NoBalance
+	}
+
 	return errors.UnknownError
 }

--- a/chain/cardano/errors.go
+++ b/chain/cardano/errors.go
@@ -1,0 +1,7 @@
+package newchain
+
+import "github.com/cordialsys/crosschain/client/errors"
+
+func CheckError(err error) errors.Status {
+	return ""
+}

--- a/chain/cardano/tx/tx.go
+++ b/chain/cardano/tx/tx.go
@@ -1,0 +1,437 @@
+package tx
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	xc "github.com/cordialsys/crosschain"
+	xcbuilder "github.com/cordialsys/crosschain/builder"
+	"github.com/cordialsys/crosschain/chain/cardano/client/types"
+	"github.com/cordialsys/crosschain/chain/cardano/tx_input"
+	"github.com/cosmos/btcutil/bech32"
+	"github.com/fxamacker/cbor/v2"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/blake2b"
+)
+
+const (
+	// PolicyId is 28 byte hash of the token policy
+	PolicyIdLen = 56
+	Lovelace    = "lovelace"
+	FeeMargin   = 500
+)
+
+// Tx for Cardano
+type Tx struct {
+	_       struct{} `cbor:",toarray"`
+	Body    *TxBody
+	Witness *Witness
+	Valid   bool
+	Memo    *string
+}
+
+func newTx() *Tx {
+	return &Tx{
+		Body: &TxBody{
+			Inputs:  make([]*Input, 0),
+			Outputs: make([]*Output, 0),
+		},
+		Witness: &Witness{
+			Keys: make([]*VKeyWitness, 0),
+		},
+		Valid: true,
+	}
+}
+
+type TxBody struct {
+	Inputs   []*Input  `cbor:"0,keyasint"`
+	Outputs  []*Output `cbor:"1,keyasint"`
+	Fee      uint64    `cbor:"2,keyasint"`
+	TTL      uint32    `cbor:"3,keyasint,omitempty"`
+	MemoHash []byte    `cbor:"7,keyasint,omitempty"`
+}
+
+type Input struct {
+	_ struct{} `cbor:",toarray"`
+
+	TxHash []byte
+	Index  uint16
+}
+
+type PolicyHash [28]byte
+type TokenNameHexToAmount map[string]uint64
+type TokenAmounts struct {
+	_                 struct{} `cbor:",toarray"`
+	NativeAmount      uint64
+	PolicyIdToAmounts map[PolicyHash]TokenNameHexToAmount
+}
+
+type Output struct {
+	Address       []byte
+	TokenAmounts  TokenAmounts
+	NameLengthSum uint64
+}
+
+func DecodeToBase256(bech string) (string, []byte, error) {
+	hrp, data, err := bech32.DecodeNoLimit(bech)
+	if err != nil {
+		return "", nil, err
+	}
+
+	converted, err := bech32.ConvertBits(data, 5, 8, false)
+	if err != nil {
+		return "", nil, err
+	}
+	return hrp, converted, nil
+}
+
+func NewOutput(address xc.Address) (*Output, error) {
+	_, receiverAddressBytes, err := DecodeToBase256(string(address))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode address: %w", err)
+	}
+
+	return &Output{
+		Address: receiverAddressBytes,
+	}, nil
+}
+
+func (o *Output) MarshalCBOR() ([]byte, error) {
+	nativeOutput := o.TokenAmounts.PolicyIdToAmounts == nil
+	if nativeOutput {
+		type output struct {
+			_       struct{} `cbor:",toarray"`
+			Address []byte
+			Amount  uint64
+		}
+		nativeOutput := output{
+			Address: o.Address,
+			Amount:  o.TokenAmounts.NativeAmount,
+		}
+		return cbor.Marshal(nativeOutput)
+	} else {
+		type output struct {
+			Address []byte       `cbor:"0,keyasint"`
+			Amounts TokenAmounts `cbor:"1,keyasint"`
+		}
+
+		tokenOutput := output{
+			Address: o.Address,
+			Amounts: o.TokenAmounts,
+		}
+
+		return cbor.Marshal(tokenOutput)
+	}
+}
+
+func (to *Output) AddAmount(amount uint64, contract xc.ContractAddress) error {
+	if contract == Lovelace || contract == "" {
+		to.TokenAmounts.NativeAmount = amount
+		return nil
+	}
+
+	policyId := string(contract[:PolicyIdLen])
+	assetName, err := hex.DecodeString(string(contract[PolicyIdLen:]))
+	policyHashRaw, err := hex.DecodeString(policyId)
+	if err != nil {
+		return fmt.Errorf("failed to decode policyId: %w", err)
+	}
+	policyHash := PolicyHash(policyHashRaw)
+
+	if to.TokenAmounts.PolicyIdToAmounts == nil {
+		to.TokenAmounts.PolicyIdToAmounts = make(map[PolicyHash]TokenNameHexToAmount)
+	}
+
+	_, ok := to.TokenAmounts.PolicyIdToAmounts[policyHash]
+	if !ok {
+		to.TokenAmounts.PolicyIdToAmounts[policyHash] = make(TokenNameHexToAmount, 0)
+	}
+	tokenAmounts := to.TokenAmounts.PolicyIdToAmounts[policyHash]
+	tokenAmounts[string(assetName)] = amount
+
+	return nil
+}
+
+type Witness struct {
+	Keys []*VKeyWitness `cbor:"0,keyasint,omitempty"`
+}
+
+func (w *Witness) MarshalCBOR() ([]byte, error) {
+	type arrayWitness struct {
+		Keys cbor.Tag `cbor:"0,keyasint,omitempty"`
+	}
+	witness := arrayWitness{
+		Keys: cbor.Tag{
+			Number:  258,
+			Content: w.Keys,
+		},
+	}
+	return cbor.Marshal(witness)
+}
+
+type VKeyWitness struct {
+	_         struct{} `cbor:",toarray"`
+	VKey      []byte
+	Signature []byte
+}
+
+var _ xc.Tx = &Tx{}
+
+func CalcMinUtxoValue(coinsPerUtxoWord uint64) xc.AmountBlockchain {
+	return xc.NewAmountBlockchainFromUint64(0)
+}
+
+func CreateOutput(args xcbuilder.TransferArgs, input tx_input.TxInput) (*Output, error) {
+	// Create first output
+	receiverAddress := args.GetTo()
+	output, err := NewOutput(receiverAddress)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create output: %w", err)
+	}
+
+	amount := args.GetAmount()
+	contract, ok := args.GetContract()
+	isNative := !ok
+	output.AddAmount(amount.Uint64(), contract)
+	if !isNative {
+		minLovelace := CalcMinUtxoValue(input.CoinsPerUtxoWord.Uint64())
+		output.AddAmount(minLovelace.Uint64(), xc.ContractAddress(Lovelace))
+	}
+
+	return output, nil
+}
+
+// CreateChangeOutput creates a change output for the transaction
+// 1. Calculate total contract amounts from utxos
+// 2. Calculate total contract amounts from output
+// 3. Calculate change amounts for both native and token outputs
+// 4. Create change output
+func CreateChangeOutput(utxos []types.Utxo, output *Output, args xcbuilder.TransferArgs) (*Output, error) {
+	if output == nil {
+		return nil, errors.New("invalid output")
+	}
+
+	// Calculate total input amounts
+	inputAmounts := make(map[xc.ContractAddress]xc.AmountBlockchain)
+	for _, utxo := range utxos {
+		for _, amount := range utxo.Amounts {
+			contract := xc.ContractAddress(amount.Unit)
+			inputAmount, ok := inputAmounts[contract]
+			if !ok {
+				inputAmount = xc.NewAmountBlockchainFromUint64(0)
+			}
+			inputQuantity := xc.NewAmountBlockchainFromStr(amount.Quantity)
+			inputAmounts[contract] = inputAmount.Add(&inputQuantity)
+			log.WithFields(log.Fields{
+				"contract": contract,
+				"amount":   inputAmount,
+			}).Debug("input amount")
+		}
+	}
+
+	// Make sure that inputs contain lovelace
+	_, ok := inputAmounts[Lovelace]
+	if !ok {
+		return nil, errors.New("missing lovelace input")
+	}
+
+	// Calculate total output amounts
+	totalOutputs := make(map[xc.ContractAddress]xc.AmountBlockchain)
+	// Include native output first
+	nativeOutput := xc.NewAmountBlockchainFromUint64(output.TokenAmounts.NativeAmount)
+	if nativeOutput.IsZero() {
+		return nil, errors.New("outputs with 0 lovelace are invalid")
+	}
+	totalOutputs[Lovelace] = nativeOutput
+	for policyId, amounts := range output.TokenAmounts.PolicyIdToAmounts {
+		hexPolId := hex.EncodeToString(policyId[:])
+
+		for assetName, tokenAmount := range amounts {
+			contract := xc.ContractAddress(fmt.Sprintf("%s%s", hexPolId, assetName))
+			totalOutputs[contract] = xc.NewAmountBlockchainFromUint64(tokenAmount)
+			log.WithFields(log.Fields{
+				"contract": contract,
+				"amount":   tokenAmount,
+			}).Debug("output amount")
+		}
+	}
+
+	// Iterate over inputs and calculate change amounts
+	changeOutput, err := NewOutput(args.GetFrom())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create change output: %w", err)
+	}
+	zeroAmount := xc.NewAmountBlockchainFromUint64(0)
+	for contract, inputAmount := range inputAmounts {
+		outputAmount, ok := totalOutputs[contract]
+		if !ok {
+			outputAmount = zeroAmount
+		}
+
+		changeAmount := inputAmount.Sub(&outputAmount)
+		if changeAmount.Cmp(&zeroAmount) == -1 {
+			return nil, fmt.Errorf("negative change amount for contract %s", contract)
+		}
+		changeOutput.AddAmount(inputAmount.Uint64(), contract)
+		log.WithFields(log.Fields{
+			"contract": contract,
+			"amount":   changeAmount,
+		}).Debug("change amount")
+	}
+
+	return changeOutput, nil
+}
+
+// Create Cardano transaction
+// 1. Create raw transaction
+// 2. Create inputs
+// 3. Create recipient output
+// 4. Create change output
+// 5. Create dummy signature for fee estimation
+// 6. Deduct fee from change output
+func NewTx(args xcbuilder.TransferArgs, input tx_input.TxInput) (xc.Tx, error) {
+	tx := newTx()
+
+	inputMemo, ok := args.GetMemo()
+	if ok {
+		tx.Memo = &inputMemo
+		bytes, err := cbor.Marshal(inputMemo)
+		if err != nil {
+			return nil, errors.New("failed to marshal memo")
+		}
+		hash := blake2b.Sum256(bytes)
+		tx.Body.MemoHash = hash[:]
+	}
+
+	// Create inputs
+	for _, utxo := range input.Utxos {
+		hehHash, err := hex.DecodeString(utxo.TxHash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode hash: %w", err)
+		}
+		txInput := &Input{
+			TxHash: hehHash,
+			Index:  utxo.Index,
+		}
+		tx.Body.Inputs = append(tx.Body.Inputs, txInput)
+	}
+
+	// Recipient output
+	output, err := CreateOutput(args, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create output: %w", err)
+	}
+	tx.Body.Outputs = append(tx.Body.Outputs, output)
+
+	// Change output
+	changeOutput, err := CreateChangeOutput(input.Utxos, output, args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create change output: %w", err)
+	}
+	tx.Body.Outputs = append(tx.Body.Outputs, changeOutput)
+
+	tx.Body.TTL = uint32(input.Slot + 3600*2) // 2 hours
+
+	// Witness for fee estimation
+	dummyWitness := &VKeyWitness{
+		VKey:      make([]byte, 32),
+		Signature: make([]byte, 64),
+	}
+	tx.Witness.Keys = append(tx.Witness.Keys, dummyWitness)
+	// Make sure to zero out the dummy witness
+	defer func() {
+		tx.Witness.Keys = make([]*VKeyWitness, 0)
+	}()
+
+	// Serialize tx with dummy signature for fee estimation
+	txCbor, err := cbor.Marshal(tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal tx: %w", err)
+	}
+
+	// Calculate fee
+	txSize := xc.NewAmountBlockchainFromUint64(uint64(len(txCbor)))
+	feeMargin := xc.NewAmountBlockchainFromUint64(FeeMargin)
+	fee := input.FeePerByte
+	fee = fee.Mul(&txSize)
+	fee = fee.Add(&input.FixedFee)
+	fee = fee.Add(&feeMargin)
+	tx.Body.Fee = fee.Uint64()
+
+	// Deduct fee from the change
+	tx.Body.Outputs[1].TokenAmounts.NativeAmount -= tx.Body.Fee
+	return tx, nil
+}
+
+// Hash returns the tx hash or id
+func (tx Tx) Hash() xc.TxHash {
+	txCbor, err := cbor.Marshal(tx.Body)
+	if err != nil {
+		return xc.TxHash("")
+	}
+
+	blake2bHash := blake2b.Sum256(txCbor)
+
+	return xc.TxHash(hex.EncodeToString(blake2bHash[:]))
+}
+
+// Sighashes returns the tx payload to sign, aka sighash
+func (tx Tx) Sighashes() ([]*xc.SignatureRequest, error) {
+	txCbor, err := cbor.Marshal(tx.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal tx: %w", err)
+	}
+	hash := blake2b.Sum256(txCbor)
+	signatureData := &xc.SignatureRequest{
+		Payload: hash[:],
+	}
+	println("Sighash: ", hex.EncodeToString(signatureData.Payload))
+
+	return []*xc.SignatureRequest{signatureData}, nil
+}
+
+// AddSignatures adds a signature to Tx
+func (tx *Tx) AddSignatures(signatures ...*xc.SignatureResponse) error {
+	if len(signatures) == 0 {
+		return nil
+	}
+
+	if len(tx.Witness.Keys) != 0 {
+		return errors.New("tx already signed")
+	}
+
+	for _, sig := range signatures {
+		vKeyWitness := &VKeyWitness{
+			VKey:      sig.PublicKey,
+			Signature: sig.Signature,
+		}
+		tx.Witness.Keys = append(tx.Witness.Keys, vKeyWitness)
+	}
+	cborWitness, err := cbor.Marshal(tx.Witness)
+	if err != nil {
+		return fmt.Errorf("failed to marshal witness: %w", err)
+	}
+	fmt.Printf("Witness: %x\n", cborWitness)
+
+	return nil
+}
+
+// GetSignatures returns back signatures, which may be used for signed-transaction broadcasting
+func (tx *Tx) GetSignatures() []xc.TxSignature {
+	signatures := make([]xc.TxSignature, len(tx.Witness.Keys))
+	for _, witness := range tx.Witness.Keys {
+		signatures = append(signatures, xc.TxSignature(witness.Signature))
+	}
+	return signatures
+}
+
+// Serialize returns the serialized tx
+func (tx Tx) Serialize() ([]byte, error) {
+	txCbor, err := cbor.Marshal(tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal tx: %w", err)
+	}
+
+	return txCbor, nil
+}

--- a/chain/cardano/tx/tx_test.go
+++ b/chain/cardano/tx/tx_test.go
@@ -1,0 +1,62 @@
+package tx_test
+
+import (
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/chain/cardano/tx"
+	"github.com/cordialsys/crosschain/chain/template/tx"
+	"github.com/test-go/testify/require"
+)
+
+func TestTxHash(t *testing.T) {
+
+	tx1 := tx.Tx{}
+	require.Equal(t, xc.TxHash("not implemented"), tx1.Hash())
+}
+
+func TestTxSighashes(t *testing.T) {
+
+	tx1 := tx.Tx{}
+	sighashes, err := tx1.Sighashes()
+	require.NotNil(t, sighashes)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestTxAddSignature(t *testing.T) {
+
+	tx1 := tx.Tx{}
+	err := tx1.AddSignatures([]xc.TxSignature{}...)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestTxBody_MarshalCBOR(t *testing.T) {
+	tests := []struct {
+		name    string // description of this test case
+		want    []byte
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// TODO: construct the receiver type.
+			var tb tx.TxBody
+			got, gotErr := tb.MarshalCBOR()
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("MarshalCBOR() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("MarshalCBOR() succeeded unexpectedly")
+			}
+			// TODO: update the condition below to compare got with tt.want.
+			if true {
+				t.Errorf("MarshalCBOR() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+

--- a/chain/cardano/tx/tx_test.go
+++ b/chain/cardano/tx/tx_test.go
@@ -1,62 +1,120 @@
 package tx_test
 
 import (
+	"encoding/hex"
 	"testing"
 
 	xc "github.com/cordialsys/crosschain"
+	xcbuilder "github.com/cordialsys/crosschain/builder"
+	"github.com/cordialsys/crosschain/chain/cardano/client/types"
 	"github.com/cordialsys/crosschain/chain/cardano/tx"
-	"github.com/cordialsys/crosschain/chain/template/tx"
-	"github.com/test-go/testify/require"
+	"github.com/cordialsys/crosschain/chain/cardano/tx_input"
+	"github.com/stretchr/testify/require"
 )
 
-func TestTxHash(t *testing.T) {
+func newTx(t *testing.T) *tx.Tx {
+	fromAddr := xc.Address("addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5")
+	toAddr := xc.Address("addr_test1qrfp5xelv2mu7k8zyvwm0c8t5xm55wanwhtd4fgjgtf3ck0rplhn7x9jyhwqg70fwv0ujpmyumqk5td9e9hnsejtlxnq3yqf25")
+	amount := xc.NewAmountBlockchainFromUint64(1_000_000)
 
-	tx1 := tx.Tx{}
-	require.Equal(t, xc.TxHash("not implemented"), tx1.Hash())
+	transferArgs, err := xcbuilder.NewTransferArgs(fromAddr, toAddr, amount)
+	require.NoError(t, err)
+
+	transferInput := tx_input.TxInput{
+		Utxos: []types.Utxo{
+			{
+				Address: "addr_test1vzjddf57t45k7a04kpr65lakpjmx50pwy7v0eje3t73c02s5zecy5",
+				Amounts: []types.Amount{
+					{
+						Unit:     "lovelace",
+						Quantity: "5333004",
+					},
+				},
+				TxHash: "72cfa181469b48402a50c6652d45c789897ae5025bb01f569a7bd01bffd12bc1",
+				Index:  1,
+			},
+		},
+		Slot:             90_751_416,
+		FixedFee:         xc.NewAmountBlockchainFromUint64(155_381),
+		FeePerByte:       xc.NewAmountBlockchainFromUint64(44),
+		MinUtxo:          xc.NewAmountBlockchainFromUint64(4_310),
+		CoinsPerUtxoWord: xc.NewAmountBlockchainFromUint64(4_310),
+	}
+
+	transaction, err := tx.NewTx(transferArgs, transferInput)
+	require.NoError(t, err)
+	return transaction.(*tx.Tx)
+}
+
+func TestTxHash(t *testing.T) {
+	tx := newTx(t)
+	expectedHash := xc.TxHash("57004dd0ec9c90ed1d0a68497466b67f98c51b2027dc39906b7ae74d0dde3b3a")
+	require.Equal(t, expectedHash, tx.Hash())
 }
 
 func TestTxSighashes(t *testing.T) {
-
-	tx1 := tx.Tx{}
-	sighashes, err := tx1.Sighashes()
+	tx := newTx(t)
+	sighashes, err := tx.Sighashes()
 	require.NotNil(t, sighashes)
-	require.EqualError(t, err, "not implemented")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(sighashes))
+	require.Equal(t, "57004dd0ec9c90ed1d0a68497466b67f98c51b2027dc39906b7ae74d0dde3b3a", hex.EncodeToString(sighashes[0].Payload))
 }
 
 func TestTxAddSignature(t *testing.T) {
-
-	tx1 := tx.Tx{}
-	err := tx1.AddSignatures([]xc.TxSignature{}...)
-	require.EqualError(t, err, "not implemented")
-}
-
-func TestTxBody_MarshalCBOR(t *testing.T) {
-	tests := []struct {
-		name    string // description of this test case
-		want    []byte
-		wantErr bool
-	}{
-		// TODO: Add test cases.
+	txWithWitness := newTx(t)
+	txWithWitness.Witness = &tx.Witness{
+		Keys: []*tx.VKeyWitness{
+			{
+				VKey:      []byte{},
+				Signature: []byte{},
+			},
+		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// TODO: construct the receiver type.
-			var tb tx.TxBody
-			got, gotErr := tb.MarshalCBOR()
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("MarshalCBOR() failed: %v", gotErr)
-				}
-				return
+
+	vectors := []struct {
+		name string
+		tx   *tx.Tx
+		sigs []*xc.SignatureResponse
+		err  string
+	}{
+		{
+			name: "ValidSignature",
+			tx:   newTx(t),
+			sigs: []*xc.SignatureResponse{
+				{
+					Signature: xc.TxSignature("b9af112fa07e603c08827c2752eaf09ff0afc0726c8c5a3d923e743398e6a0c141b5476623faa88a451ae3fce2518c9502768d777e7c96d509cfbc62502d300a"),
+				}},
+			err: "",
+		},
+		{
+			name: "AlreadySigned",
+			tx:   txWithWitness,
+			sigs: []*xc.SignatureResponse{
+				{
+					Signature: xc.TxSignature("b9af112fa07e603c08827c2752eaf09ff0afc0726c8c5a3d923e743398e6a0c141b5476623faa88a451ae3fce2518c9502768d777e7c96d509cfbc62502d300a"),
+				}},
+			err: "tx already signed",
+		},
+		{
+			name: "EmptySigs",
+			tx:   newTx(t),
+			sigs: []*xc.SignatureResponse{},
+			err:  "no signatures provided",
+		},
+	}
+
+	for _, vector := range vectors {
+		t.Run(vector.name, func(t *testing.T) {
+			err := vector.tx.AddSignatures(vector.sigs...)
+			if vector.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.ErrorContains(t, err, vector.err)
 			}
-			if tt.wantErr {
-				t.Fatal("MarshalCBOR() succeeded unexpectedly")
-			}
-			// TODO: update the condition below to compare got with tt.want.
-			if true {
-				t.Errorf("MarshalCBOR() = %v, want %v", got, tt.want)
-			}
+
 		})
 	}
-}
 
+}

--- a/chain/cardano/tx/tx_test.go
+++ b/chain/cardano/tx/tx_test.go
@@ -34,11 +34,7 @@ func newTx(t *testing.T) *tx.Tx {
 				Index:  1,
 			},
 		},
-		Slot:             90_751_416,
-		FixedFee:         xc.NewAmountBlockchainFromUint64(155_381),
-		FeePerByte:       xc.NewAmountBlockchainFromUint64(44),
-		MinUtxo:          xc.NewAmountBlockchainFromUint64(4_310),
-		CoinsPerUtxoWord: xc.NewAmountBlockchainFromUint64(4_310),
+		Slot: 90_751_416,
 	}
 
 	transaction, err := tx.NewTx(transferArgs, transferInput)
@@ -48,7 +44,7 @@ func newTx(t *testing.T) *tx.Tx {
 
 func TestTxHash(t *testing.T) {
 	tx := newTx(t)
-	expectedHash := xc.TxHash("57004dd0ec9c90ed1d0a68497466b67f98c51b2027dc39906b7ae74d0dde3b3a")
+	expectedHash := xc.TxHash("53c1a2f0954b7827da2294a13242fc8cd6046ee346bdff8072e3db82335d1d86")
 	require.Equal(t, expectedHash, tx.Hash())
 }
 
@@ -58,7 +54,7 @@ func TestTxSighashes(t *testing.T) {
 	require.NotNil(t, sighashes)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sighashes))
-	require.Equal(t, "57004dd0ec9c90ed1d0a68497466b67f98c51b2027dc39906b7ae74d0dde3b3a", hex.EncodeToString(sighashes[0].Payload))
+	require.Equal(t, "53c1a2f0954b7827da2294a13242fc8cd6046ee346bdff8072e3db82335d1d86", hex.EncodeToString(sighashes[0].Payload))
 }
 
 func TestTxAddSignature(t *testing.T) {

--- a/chain/cardano/tx_input/tx_input.go
+++ b/chain/cardano/tx_input/tx_input.go
@@ -6,6 +6,8 @@ import (
 	"github.com/cordialsys/crosschain/factory/drivers/registry"
 )
 
+const FeeMargin = 500
+
 // TxInput for Template
 type TxInput struct {
 	xc.TxInputEnvelope
@@ -39,28 +41,48 @@ func (input *TxInput) GetDriver() xc.Driver {
 	return xc.DriverCardano
 }
 
+// Cardano does not support fee bidding
 func (input *TxInput) SetGasFeePriority(other xc.GasFeePriority) error {
-	multiplier, err := other.GetDefault()
-	if err != nil {
-		return err
-	}
-	// multiply the gas price using the default, or apply a strategy according to the enum
-	_ = multiplier
 	return nil
 }
 
+// FIXME: Cardano fee calculation requires a TX size
 func (input *TxInput) GetFeeLimit() (xc.AmountBlockchain, xc.ContractAddress) {
-	// get the max possible fee that could be spent on this transaction
 	return xc.NewAmountBlockchainFromUint64(0), ""
 }
 
+// check if any utxo is spent twice
 func (input *TxInput) IndependentOf(other xc.TxInput) (independent bool) {
-	// are these two transactions independent (e.g. different sequences & utxos & expirations?)
-	// default false
-	return
+	cardanoOther, ok := other.(*TxInput)
+	if !ok {
+		return
+	}
+
+	for _, utxo1 := range input.Utxos {
+		for _, utxo2 := range cardanoOther.Utxos {
+			if utxo1.TxHash == utxo2.TxHash && utxo1.Index == utxo2.Index {
+				// not independent
+				return false
+			}
+		}
+	}
+
+	return true
 }
 func (input *TxInput) SafeFromDoubleSend(others ...xc.TxInput) (safe bool) {
-	// safe from double send ?
-	// default false
-	return
+	// check if of the same types
+	for _, other := range others {
+		if _, ok := other.(*TxInput); !ok {
+			return false
+		}
+	}
+
+	// we are risking double send if we have any independent utxo's
+	for _, other := range others {
+		if input.IndependentOf(other) {
+			return false
+		}
+	}
+	// conflicting utxo for all - we're safe
+	return true
 }

--- a/chain/cardano/tx_input/tx_input.go
+++ b/chain/cardano/tx_input/tx_input.go
@@ -1,0 +1,66 @@
+package tx_input
+
+import (
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/chain/cardano/client/types"
+	"github.com/cordialsys/crosschain/factory/drivers/registry"
+)
+
+// TxInput for Template
+type TxInput struct {
+	xc.TxInputEnvelope
+	Utxos []types.Utxo `json:"utxos"`
+	Slot  uint64       `json:"slot"`
+	// FixedFee is defined as the minimum fee for a transaction
+	FixedFee xc.AmountBlockchain `json:"min_fee_b"`
+	// FeePerByte is the fee per transaction byte
+	FeePerByte xc.AmountBlockchain `json:"min_fee_a"`
+	// MinUtxo is the amount of minimum utxo value for ADA only transactions
+	MinUtxo xc.AmountBlockchain `json:"min_utxo"`
+	// CoinsPerUtxoWord is the price per utxo word for multi-asset transactions
+	CoinsPerUtxoWord xc.AmountBlockchain `json:"price_per_utxo_word"`
+}
+
+var _ xc.TxInput = &TxInput{}
+
+func init() {
+	registry.RegisterTxBaseInput(&TxInput{})
+}
+
+func NewTxInput() *TxInput {
+	return &TxInput{
+		TxInputEnvelope: xc.TxInputEnvelope{
+			Type: xc.DriverCardano,
+		},
+	}
+}
+
+func (input *TxInput) GetDriver() xc.Driver {
+	return xc.DriverCardano
+}
+
+func (input *TxInput) SetGasFeePriority(other xc.GasFeePriority) error {
+	multiplier, err := other.GetDefault()
+	if err != nil {
+		return err
+	}
+	// multiply the gas price using the default, or apply a strategy according to the enum
+	_ = multiplier
+	return nil
+}
+
+func (input *TxInput) GetFeeLimit() (xc.AmountBlockchain, xc.ContractAddress) {
+	// get the max possible fee that could be spent on this transaction
+	return xc.NewAmountBlockchainFromUint64(0), ""
+}
+
+func (input *TxInput) IndependentOf(other xc.TxInput) (independent bool) {
+	// are these two transactions independent (e.g. different sequences & utxos & expirations?)
+	// default false
+	return
+}
+func (input *TxInput) SafeFromDoubleSend(others ...xc.TxInput) (safe bool) {
+	// safe from double send ?
+	// default false
+	return
+}

--- a/chain/cardano/tx_input/tx_input.go
+++ b/chain/cardano/tx_input/tx_input.go
@@ -6,8 +6,6 @@ import (
 	"github.com/cordialsys/crosschain/factory/drivers/registry"
 )
 
-const FeeMargin = 500
-
 // TxInput for Template
 type TxInput struct {
 	xc.TxInputEnvelope

--- a/chain/cardano/tx_input/tx_input.go
+++ b/chain/cardano/tx_input/tx_input.go
@@ -11,16 +11,10 @@ const FeeMargin = 500
 // TxInput for Template
 type TxInput struct {
 	xc.TxInputEnvelope
-	Utxos []types.Utxo `json:"utxos"`
-	Slot  uint64       `json:"slot"`
-	// FixedFee is defined as the minimum fee for a transaction
-	FixedFee xc.AmountBlockchain `json:"min_fee_b"`
-	// FeePerByte is the fee per transaction byte
-	FeePerByte xc.AmountBlockchain `json:"min_fee_a"`
-	// MinUtxo is the amount of minimum utxo value for ADA only transactions
-	MinUtxo xc.AmountBlockchain `json:"min_utxo"`
-	// CoinsPerUtxoWord is the price per utxo word for multi-asset transactions
-	CoinsPerUtxoWord xc.AmountBlockchain `json:"price_per_utxo_word"`
+	Utxos                   []types.Utxo `json:"utxos"`
+	Slot                    uint64       `json:"slot"`
+	Fee                     uint64       `json:"fee"`
+	TransactionValidityTime uint64       `json:"transaction_validity_time"`
 }
 
 var _ xc.TxInput = &TxInput{}
@@ -46,9 +40,8 @@ func (input *TxInput) SetGasFeePriority(other xc.GasFeePriority) error {
 	return nil
 }
 
-// FIXME: Cardano fee calculation requires a TX size
 func (input *TxInput) GetFeeLimit() (xc.AmountBlockchain, xc.ContractAddress) {
-	return xc.NewAmountBlockchainFromUint64(0), ""
+	return xc.NewAmountBlockchainFromUint64(input.Fee), ""
 }
 
 // check if any utxo is spent twice

--- a/chain/cardano/tx_input/tx_input_test.go
+++ b/chain/cardano/tx_input/tx_input_test.go
@@ -1,29 +1,19 @@
 package tx_input_test
 
 import (
-	"encoding/json"
-	"fmt"
 	"testing"
 
 	xc "github.com/cordialsys/crosschain"
-	"github.com/cordialsys/crosschain/chain/template/tx_input"
+	"github.com/cordialsys/crosschain/chain/cardano/client/types"
+	"github.com/cordialsys/crosschain/chain/cardano/tx_input"
 	"github.com/test-go/testify/require"
 )
 
 type TxInput = tx_input.TxInput
 
-func TestSafeFromDoubleSpend(t *testing.T) {
-
-	newInput := &TxInput{}
-	oldInput1 := &TxInput{}
-	// Defaults are false but each chain has conditions
-	require.False(t, newInput.SafeFromDoubleSend(oldInput1))
-	require.False(t, newInput.IndependentOf(oldInput1))
-}
-
 func TestTxInputConflicts(t *testing.T) {
-
 	type testcase struct {
+		name     string
 		newInput xc.TxInput
 		oldInput xc.TxInput
 
@@ -32,33 +22,82 @@ func TestTxInputConflicts(t *testing.T) {
 	}
 	vectors := []testcase{
 		{
-			newInput:        &TxInput{},
-			oldInput:        &TxInput{},
-			independent:     false,
+			name: "IndependentNotSafeFromDoubleSpend",
+			newInput: &TxInput{
+				Utxos: []types.Utxo{
+					{
+						TxHash: "hash1",
+						Index:  0,
+					},
+				},
+			},
+			oldInput: &TxInput{
+				Utxos: []types.Utxo{
+					{
+						TxHash: "hash2h",
+						Index:  0,
+					},
+				},
+			},
+			independent:     true,
 			doubleSpendSafe: false,
 		},
 		{
-			newInput: &TxInput{},
-			// check no old input
-			oldInput:        nil,
-			independent:     false,
+			name: "IndependentTheSameHash",
+			newInput: &TxInput{
+				Utxos: []types.Utxo{
+					{
+						TxHash: "hash1",
+						Index:  0,
+					},
+				},
+			},
+			oldInput: &TxInput{
+				Utxos: []types.Utxo{
+					{
+						TxHash: "hash1",
+						Index:  1,
+					},
+				},
+			},
+			independent:     true,
 			doubleSpendSafe: false,
 		},
+		{
+			name: "SafeFromDoubleSpend",
+			newInput: &TxInput{
+				Utxos: []types.Utxo{
+					{
+						TxHash: "hash1",
+						Index:  0,
+					},
+				},
+			},
+			oldInput: &TxInput{
+				Utxos: []types.Utxo{
+					{
+						TxHash: "hash1",
+						Index:  0,
+					},
+				},
+			},
+			independent:     false,
+			doubleSpendSafe: true,
+		},
 	}
-	for i, v := range vectors {
-		newBz, _ := json.Marshal(v.newInput)
-		oldBz, _ := json.Marshal(v.oldInput)
-		fmt.Printf("testcase %d - expect safe=%t, independent=%t\n     newInput = %s\n     oldInput = %s\n", i, v.doubleSpendSafe, v.independent, string(newBz), string(oldBz))
-		fmt.Println()
-		require.Equal(t,
-			v.newInput.IndependentOf(v.oldInput),
-			v.independent,
-			"IndependentOf",
-		)
-		require.Equal(t,
-			v.newInput.SafeFromDoubleSend(v.oldInput),
-			v.doubleSpendSafe,
-			"SafeFromDoubleSend",
-		)
+
+	for _, v := range vectors {
+		t.Run(v.name, func(t *testing.T) {
+			require.Equal(t,
+				v.newInput.IndependentOf(v.oldInput),
+				v.independent,
+				"IndependentOf",
+			)
+			require.Equal(t,
+				v.newInput.SafeFromDoubleSend(v.oldInput),
+				v.doubleSpendSafe,
+				"SafeFromDoubleSend",
+			)
+		})
 	}
 }

--- a/chain/cardano/tx_input/tx_input_test.go
+++ b/chain/cardano/tx_input/tx_input_test.go
@@ -1,0 +1,64 @@
+package tx_input_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/chain/template/tx_input"
+	"github.com/test-go/testify/require"
+)
+
+type TxInput = tx_input.TxInput
+
+func TestSafeFromDoubleSpend(t *testing.T) {
+
+	newInput := &TxInput{}
+	oldInput1 := &TxInput{}
+	// Defaults are false but each chain has conditions
+	require.False(t, newInput.SafeFromDoubleSend(oldInput1))
+	require.False(t, newInput.IndependentOf(oldInput1))
+}
+
+func TestTxInputConflicts(t *testing.T) {
+
+	type testcase struct {
+		newInput xc.TxInput
+		oldInput xc.TxInput
+
+		independent     bool
+		doubleSpendSafe bool
+	}
+	vectors := []testcase{
+		{
+			newInput:        &TxInput{},
+			oldInput:        &TxInput{},
+			independent:     false,
+			doubleSpendSafe: false,
+		},
+		{
+			newInput: &TxInput{},
+			// check no old input
+			oldInput:        nil,
+			independent:     false,
+			doubleSpendSafe: false,
+		},
+	}
+	for i, v := range vectors {
+		newBz, _ := json.Marshal(v.newInput)
+		oldBz, _ := json.Marshal(v.oldInput)
+		fmt.Printf("testcase %d - expect safe=%t, independent=%t\n     newInput = %s\n     oldInput = %s\n", i, v.doubleSpendSafe, v.independent, string(newBz), string(oldBz))
+		fmt.Println()
+		require.Equal(t,
+			v.newInput.IndependentOf(v.oldInput),
+			v.independent,
+			"IndependentOf",
+		)
+		require.Equal(t,
+			v.newInput.SafeFromDoubleSend(v.oldInput),
+			v.doubleSpendSafe,
+			"SafeFromDoubleSend",
+		)
+	}
+}

--- a/factory/defaults/chains/mainnet.yaml
+++ b/factory/defaults/chains/mainnet.yaml
@@ -36,6 +36,7 @@ chains:
     default_gas_budget: "3.0"
     fee_limit: "30.0"
     transaction_active_time: "2h"
+    auth: "env:CARDANO_PROJECT_ID"
   AKT:
     chain: AKT
     driver: cosmos

--- a/factory/defaults/chains/mainnet.yaml
+++ b/factory/defaults/chains/mainnet.yaml
@@ -26,6 +26,15 @@ chains:
       coin_market_cap:
         chain_id:
         asset_id: "6756"
+  ADA:
+    chain: ADA
+    driver: cardano
+    chain_id: cardano
+    network: mainnet
+    chain_name: Cardano
+    decimals: 6
+    fee_limit: "3.0"
+    auth: "raw:preprodkeXbfCzkmYDogwPw4gvM6fxvYG9W1Wcm"
   AKT:
     chain: AKT
     driver: cosmos

--- a/factory/defaults/chains/mainnet.yaml
+++ b/factory/defaults/chains/mainnet.yaml
@@ -35,7 +35,6 @@ chains:
     decimals: 6
     default_gas_budget: "3.0"
     fee_limit: "30.0"
-    auth: "raw:preprodkeXbfCzkmYDogwPw4gvM6fxvYG9W1Wcm"
     transaction_active_time: "2h"
   AKT:
     chain: AKT

--- a/factory/defaults/chains/mainnet.yaml
+++ b/factory/defaults/chains/mainnet.yaml
@@ -33,8 +33,10 @@ chains:
     network: mainnet
     chain_name: Cardano
     decimals: 6
-    fee_limit: "3.0"
+    default_gas_budget: "3.0"
+    fee_limit: "30.0"
     auth: "raw:preprodkeXbfCzkmYDogwPw4gvM6fxvYG9W1Wcm"
+    transaction_active_time: "2h"
   AKT:
     chain: AKT
     driver: cosmos

--- a/factory/defaults/chains/testnet.yaml
+++ b/factory/defaults/chains/testnet.yaml
@@ -5,11 +5,14 @@ chains:
   ADA:
     chain: ADA
     driver: cardano
-    chain_id: cardano
     network: preprod
+    chain_id: cardano
     chain_name: Cardano
+    default_gas_budget: "3.0"
+    fee_limit: "30.0"
     decimals: 6
     auth: "raw:preprodkeXbfCzkmYDogwPw4gvM6fxvYG9W1Wcm"
+    transaction_active_time: "2h"
   APTOS:
     chain: APTOS
     driver: aptos

--- a/factory/defaults/chains/testnet.yaml
+++ b/factory/defaults/chains/testnet.yaml
@@ -11,7 +11,6 @@ chains:
     default_gas_budget: "3.0"
     fee_limit: "30.0"
     decimals: 6
-    auth: "raw:preprodkeXbfCzkmYDogwPw4gvM6fxvYG9W1Wcm"
     transaction_active_time: "2h"
   APTOS:
     chain: APTOS

--- a/factory/defaults/chains/testnet.yaml
+++ b/factory/defaults/chains/testnet.yaml
@@ -12,6 +12,7 @@ chains:
     fee_limit: "30.0"
     decimals: 6
     transaction_active_time: "2h"
+    auth: "env:CARDANO_PROJECT_ID"
   APTOS:
     chain: APTOS
     driver: aptos

--- a/factory/defaults/chains/testnet.yaml
+++ b/factory/defaults/chains/testnet.yaml
@@ -2,6 +2,14 @@
 
 network: "testnet"
 chains:
+  ADA:
+    chain: ADA
+    driver: cardano
+    chain_id: cardano
+    network: preprod
+    chain_name: Cardano
+    decimals: 6
+    auth: "raw:preprodkeXbfCzkmYDogwPw4gvM6fxvYG9W1Wcm"
   APTOS:
     chain: APTOS
     driver: aptos

--- a/factory/drivers/factory.go
+++ b/factory/drivers/factory.go
@@ -14,6 +14,9 @@ import (
 	bitcoinaddress "github.com/cordialsys/crosschain/chain/bitcoin/address"
 	bitcoinbuilder "github.com/cordialsys/crosschain/chain/bitcoin/builder"
 	"github.com/cordialsys/crosschain/chain/bitcoin_cash"
+	cardanoaddress "github.com/cordialsys/crosschain/chain/cardano/address"
+	cardanobuilder "github.com/cordialsys/crosschain/chain/cardano/builder"
+	cardanoclient "github.com/cordialsys/crosschain/chain/cardano/client"
 	"github.com/cordialsys/crosschain/chain/cosmos"
 	cosmosaddress "github.com/cordialsys/crosschain/chain/cosmos/address"
 	cosmosbuilder "github.com/cordialsys/crosschain/chain/cosmos/builder"
@@ -59,6 +62,8 @@ import (
 
 func NewClient(cfg ITask, driver Driver) (xclient.Client, error) {
 	switch driver {
+	case DriverCardano:
+		return cardanoclient.NewClient(cfg)
 	case DriverEVM:
 		return evmclient.NewClient(cfg)
 	case DriverEVMLegacy:
@@ -131,6 +136,8 @@ func NewStakingClient(servicesConfig *services.ServicesConfig, cfg ITask, provid
 
 func NewTxBuilder(cfg *ChainBaseConfig) (xcbuilder.FullTransferBuilder, error) {
 	switch Driver(cfg.Driver) {
+	case DriverCardano:
+		return cardanobuilder.NewTxBuilder(cfg)
 	case DriverEVM:
 		return evmbuilder.NewTxBuilder(cfg)
 	case DriverEVMLegacy:
@@ -201,6 +208,8 @@ func NewAddressBuilder(cfg *ChainBaseConfig, options ...xcaddress.AddressOption)
 		return xrpaddress.NewAddressBuilder(cfg)
 	case DriverXlm:
 		return xlmaddress.NewAddressBuilder(cfg)
+	case DriverCardano:
+		return cardanoaddress.NewAddressBuilder(cfg)
 	}
 	return nil, fmt.Errorf("no address builder defined for: %s", string(cfg.Chain))
 }

--- a/factory/drivers/factory.go
+++ b/factory/drivers/factory.go
@@ -14,6 +14,7 @@ import (
 	bitcoinaddress "github.com/cordialsys/crosschain/chain/bitcoin/address"
 	bitcoinbuilder "github.com/cordialsys/crosschain/chain/bitcoin/builder"
 	"github.com/cordialsys/crosschain/chain/bitcoin_cash"
+	cardano "github.com/cordialsys/crosschain/chain/cardano"
 	cardanoaddress "github.com/cordialsys/crosschain/chain/cardano/address"
 	cardanobuilder "github.com/cordialsys/crosschain/chain/cardano/builder"
 	cardanoclient "github.com/cordialsys/crosschain/chain/cardano/client"
@@ -219,6 +220,8 @@ func CheckError(driver Driver, err error) errors.Status {
 		return err.Status
 	}
 	switch driver {
+	case DriverCardano:
+		return cardano.CheckError(err)
 	case DriverDusk:
 		return dusk.CheckError(err)
 	case DriverEVM:

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	filippo.io/edwards25519 v1.1.0
 	github.com/cloudflare/circl v1.6.0
 	github.com/fxamacker/cbor v1.5.1
+	github.com/fxamacker/cbor/v2 v2.8.0
 	golang.org/x/time v0.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -507,6 +507,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor v1.5.1 h1:XjQWBgdmQyqimslUh5r4tUGmoqzHmBFQOImkWGi2awg=
 github.com/fxamacker/cbor v1.5.1/go.mod h1:3aPGItF174ni7dDzd6JZ206H8cmr4GDNBGpPa971zsU=
+github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
+github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gagliardetto/binary v0.8.0 h1:U9ahc45v9HW0d15LoN++vIXSJyqR/pWw8DDlhd7zvxg=
 github.com/gagliardetto/binary v0.8.0/go.mod h1:2tfj51g5o9dnvsc+fL3Jxr22MuWzYXwx9wEoN0XQ7/c=
 github.com/gagliardetto/gofuzz v1.2.2 h1:XL/8qDMzcgvR4+CyRQW9UGdwPRPMHVJfqQ/uMvSUuQw=


### PR DESCRIPTION
# Cardano
It supports multiple api options, however nothing is really native.

What I considered:
- https://github.com/cardano-foundation/cardano-rosetta - rosetta based api - transaction submission feels running in circles, and they require to submit transaction that is assembled on their side, which sounds dangerous
- https://developers.cardano.org/docs/get-started/ogmios - lack of fetching `utxo` from the account, they suggest running indexing node
- https://developers.cardano.org/docs/get-started/koios
- https://developers.cardano.org/docs/get-started/blockfrost/overview

In the end I decided to use `blockfrost` - it is a simple rest api, with really good documentation and great examples.

## Fees

Cardano uses "First come, first served" approach - there is no bidding. Fee calculation depends on two `protocol_parameters`: `min_fee_a` - cost per tx byte, and `min_fee_b` - fixed cost.
Fee formula: `size(tx) * min_fee_a + min_fee_b`.

https://docs.cardano.org/about-cardano/explore-more/fee-structure#:~:text=Cardano's%20fee%20structure%20is%20quite,a%2Fb%20are%20protocol%20parameters

## Tokens

Cardano supports tokens. Token UTXO are required to contain minimal value of UTXO, which is calculated from `tx without value` size, rounded up to bytes and multiplied by `coin_per_utxo_word` network parameter. More about this here: https://cardano-ledger.readthedocs.io/en/latest/explanations/min-utxo-mary.html and here: https://cardano-ledger.readthedocs.io/en/latest/explanations/min-utxo-alonzo.html