### PR TITLE
cfg: add http-timeout configuration

### DIFF
--- a/builder/multi.go
+++ b/builder/multi.go
@@ -69,6 +69,16 @@ func NewMultiTransferArgs(chain xc.NativeAsset, spenders []*Sender, receivers []
 		}
 	}
 	switch chain.Driver() {
+	case xc.DriverBitcoin, xc.DriverBitcoinCash, xc.DriverBitcoinLegacy, xc.DriverCardano, xc.DriverSui:
+		// check for address dups
+		for i, s1 := range spenders {
+			for j, s2 := range spenders {
+				if i != j && s1.address == s2.address {
+					return nil, errors.New("cannot use the same address multiple times in a batch transaction for a UTXO-based chain")
+				}
+			}
+		}
+
 	case xc.DriverEVM, xc.DriverEVMLegacy:
 		if len(spenders) != 1 {
 			return nil, errors.New("only one spender is supported for account-based chains")

--- a/chain/bitcoin/client/blockbook/blockbook.go
+++ b/chain/bitcoin/client/blockbook/blockbook.go
@@ -47,7 +47,7 @@ var _ address.WithAddressDecoder = &BlockbookClient{}
 func NewClient(cfgI xc.ITask) (*BlockbookClient, error) {
 	asset := cfgI
 	cfg := cfgI.GetChain()
-	httpClient := http.Client{}
+	httpClient := cfg.DefaultHttpClient()
 	chaincfg, err := params.GetParams(cfg.Base())
 	if err != nil {
 		return &BlockbookClient{}, err
@@ -57,7 +57,7 @@ func NewClient(cfgI xc.ITask) (*BlockbookClient, error) {
 	decoder := address.NewAddressDecoder()
 
 	return &BlockbookClient{
-		httpClient,
+		*httpClient,
 		asset,
 		chaincfg,
 		url,

--- a/chain/bitcoin/client/blockchair/blockchair.go
+++ b/chain/bitcoin/client/blockchair/blockchair.go
@@ -44,7 +44,7 @@ var _ address.WithAddressDecoder = &BlockchairClient{}
 func NewBlockchairClient(cfgI xc.ITask) (*BlockchairClient, error) {
 	asset := cfgI
 	cfg := cfgI.GetChain()
-	httpClient := http.Client{}
+	httpClient := cfg.DefaultHttpClient()
 	params, err := params.GetParams(cfg.Base())
 	if err != nil {
 		return &BlockchairClient{}, err
@@ -62,7 +62,7 @@ func NewBlockchairClient(cfgI xc.ITask) (*BlockchairClient, error) {
 		ApiKey:           apiKey,
 		Url:              cfg.URL,
 		Chaincfg:         params,
-		httpClient:       httpClient,
+		httpClient:       *httpClient,
 		Asset:            asset,
 		addressDecoder:   &address.BtcAddressDecoder{},
 		skipAmountFilter: false,

--- a/chain/cardano/client/client.go
+++ b/chain/cardano/client/client.go
@@ -69,7 +69,7 @@ func NewClient(cfgI xc.ITask) (*Client, error) {
 		Network:             network,
 		Logger:              logger,
 		BlockfrostProjectId: chainConfig.Auth2.LoadOrBlank(),
-		HttpClient:          http.DefaultClient,
+		HttpClient:          chainConfig.DefaultHttpClient(),
 	}, nil
 }
 

--- a/chain/cosmos/client/client.go
+++ b/chain/cosmos/client/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
 
 	comettypes "github.com/cometbft/cometbft/rpc/core/types"
@@ -79,13 +78,12 @@ func NewClient(cfgI xc.ITask) (*Client, error) {
 	host := cfg.URL
 	interceptor := utils.NewHttpInterceptor(ReplaceIncompatiableCosmosResponses)
 	interceptor.Enable()
+	rawHttpClient := cfg.DefaultHttpClient()
 
-	rawHttpClient := &http.Client{
-		// Need to use custom transport because:
-		// - cosmos library does not parse URLs correctly
-		// - need to intercept responses to remove incompatible response fields for some chains
-		Transport: interceptor,
-	}
+	// Need to use custom transport because:
+	// - cosmos library does not parse URLs correctly
+	// - need to intercept responses to remove incompatible response fields for some chains
+	rawHttpClient.Transport = interceptor
 	httpClient, err := rpchttp.NewWithClient(
 		host,
 		rawHttpClient,

--- a/chain/crosschain/client.go
+++ b/chain/crosschain/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	xc "github.com/cordialsys/crosschain"
 	xcbuilder "github.com/cordialsys/crosschain/builder"
@@ -41,7 +42,7 @@ var _ xclient.MultiTransferClient = &Client{}
 const ServiceApiKeyHeader = "x-service-api-key"
 
 // NewClient returns a new Crosschain Client
-func NewClient(cfgI xc.ITask, url string, apiKeyRef config.Secret, network xc.NetworkSelector) (*Client, error) {
+func NewClient(cfgI xc.ITask, url string, apiKeyRef config.Secret, network xc.NetworkSelector, httpTimeout time.Duration) (*Client, error) {
 	url = strings.TrimSuffix(url, "/")
 	var apiKey string
 	var err error
@@ -57,16 +58,19 @@ func NewClient(cfgI xc.ITask, url string, apiKeyRef config.Secret, network xc.Ne
 	}
 
 	return &Client{
-		Asset:   cfgI,
-		URL:     url,
-		Http:    &http.Client{},
+		Asset: cfgI,
+		URL:   url,
+		Http: &http.Client{
+			// Prevent requests from hanging indefinitely
+			Timeout: httpTimeout,
+		},
 		Network: network,
 		ApiKey:  apiKey,
 	}, nil
 }
 
-func NewStakingClient(cfgI xc.ITask, url string, apiKeyRef config.Secret, serviceApiKey config.Secret, provider xc.StakingProvider, network xc.NetworkSelector) (*Client, error) {
-	client, err := NewClient(cfgI, url, apiKeyRef, network)
+func NewStakingClient(cfgI xc.ITask, url string, apiKeyRef config.Secret, serviceApiKey config.Secret, provider xc.StakingProvider, network xc.NetworkSelector, httpTimeout time.Duration) (*Client, error) {
+	client, err := NewClient(cfgI, url, apiKeyRef, network, httpTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/crosschain/client_test.go
+++ b/chain/crosschain/client_test.go
@@ -33,7 +33,7 @@ func TestExampleTestSuite(t *testing.T) {
 
 func (s *CrosschainTestSuite) TestNewClient() {
 	require := s.Require()
-	client, err := NewClient(s.Asset, "", "", "")
+	client, err := NewClient(s.Asset, "", "", "", 0)
 	require.NotNil(client)
 	require.Nil(err)
 }
@@ -54,7 +54,7 @@ func (s *CrosschainTestSuite) TestFetchTxInput() {
 	server, close := testtypes.MockHTTP(s.T(), string(res), 200)
 	defer close()
 
-	client, _ := NewClient(s.Asset, "", "", "")
+	client, _ := NewClient(s.Asset, "", "", "", 0)
 	client.URL = server.URL
 
 	from := xc.Address("from")
@@ -75,7 +75,7 @@ func (s *CrosschainTestSuite) TestFetchTxInputError() {
 	)
 	defer close()
 
-	client, _ := NewClient(s.Asset, "", "", "")
+	client, _ := NewClient(s.Asset, "", "", "", 0)
 	client.URL = server.URL
 
 	from := xc.Address("from")
@@ -107,7 +107,7 @@ func (s *CrosschainTestSuite) TestFetchTxInfo() {
 	server, close := testtypes.MockHTTP(s.T(), string(res), 200)
 	defer close()
 
-	client, _ := NewClient(s.Asset, "", "", "")
+	client, _ := NewClient(s.Asset, "", "", "", 0)
 	client.URL = server.URL
 
 	txHash := xc.TxHash("hash")
@@ -123,7 +123,7 @@ func (s *CrosschainTestSuite) TestFetchTxInfoError() {
 	server, close := testtypes.MockHTTP(s.T(), `{"code":3,"message":"api-error"}`, 400)
 	defer close()
 
-	client, _ := NewClient(s.Asset, "", "", "")
+	client, _ := NewClient(s.Asset, "", "", "", 0)
 	client.URL = server.URL
 
 	txHash := xc.TxHash("hash")
@@ -142,7 +142,7 @@ func (s *CrosschainTestSuite) TestSubmitTx() {
 	server, close := testtypes.MockHTTP(s.T(), string(res), 200)
 	defer close()
 
-	client, _ := NewClient(s.Asset, "", "", "")
+	client, _ := NewClient(s.Asset, "", "", "", 0)
 	client.URL = server.URL
 
 	// types.SubmitTxReq implements xc.Tx so it's easy to use here
@@ -160,7 +160,7 @@ func (s *CrosschainTestSuite) TestSubmitTxError() {
 	server, close := testtypes.MockHTTP(s.T(), `{"code":3,"message":"api-error"}`, 400)
 	defer close()
 
-	client, _ := NewClient(s.Asset, "", "", "")
+	client, _ := NewClient(s.Asset, "", "", "", 0)
 	client.URL = server.URL
 
 	// types.SubmitTxReq implements xc.Tx so it's easy to use here
@@ -185,7 +185,7 @@ func (s *CrosschainTestSuite) TestFetchBalance() {
 	server, close := testtypes.MockHTTP(s.T(), string(res), 200)
 	defer close()
 
-	client, _ := NewClient(s.Asset, "", "", "")
+	client, _ := NewClient(s.Asset, "", "", "", 0)
 	client.URL = server.URL
 
 	address := xc.Address("address")
@@ -205,7 +205,7 @@ func (s *CrosschainTestSuite) TestFetchBalanceError() {
 	server, close := testtypes.MockHTTP(s.T(), `{"code":3,"message":"api-error"}`, 400)
 	defer close()
 
-	client, _ := NewClient(s.Asset, "", "", "")
+	client, _ := NewClient(s.Asset, "", "", "", 0)
 	client.URL = server.URL
 
 	address := xc.Address("address")

--- a/chain/dusk/client/client.go
+++ b/chain/dusk/client/client.go
@@ -46,7 +46,7 @@ func NewClient(cfgI xc.ITask) (*Client, error) {
 		Asset:      cfgI,
 		Url:        cfg.GetChain().URL,
 		RuesUrl:    fmt.Sprintf("%s/on", cfg.GetChain().URL),
-		HttpClient: http.DefaultClient,
+		HttpClient: cfg.DefaultHttpClient(),
 		Logger:     logger,
 	}, nil
 }

--- a/chain/eos/client/client.go
+++ b/chain/eos/client/client.go
@@ -38,7 +38,7 @@ func NewClient(cfgI xc.ITask) (*Client, error) {
 		}
 	}
 
-	api2 := eos.New(url)
+	api2 := eos.New(url, cfgI.GetChain().DefaultHttpClient().Timeout)
 	api2.Header.Set("Content-Type", "application/json")
 	if apiKey != "" {
 		api2.Header.Set("x-api-key", apiKey)

--- a/chain/eos/eos-go/api.go
+++ b/chain/eos/eos-go/api.go
@@ -36,13 +36,13 @@ type API struct {
 	enablePartialRequiredKeys bool
 }
 
-func New(baseURL string) *API {
+func New(baseURL string, timeout time.Duration) *API {
 	api := &API{
 		HttpClient: &http.Client{
 			Transport: &http.Transport{
 				Proxy: http.ProxyFromEnvironment,
 				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
+					Timeout:   timeout,
 					KeepAlive: 30 * time.Second,
 					DualStack: true,
 				}).DialContext,
@@ -52,6 +52,7 @@ func New(baseURL string) *API {
 				ExpectContinueTimeout: 1 * time.Second,
 				DisableKeepAlives:     true, // default behavior, because of `nodeos`'s lack of support for Keep alives.
 			},
+			Timeout: timeout,
 		},
 		BaseURL:  strings.TrimRight(baseURL, "/"),
 		Compress: CompressionZlib,

--- a/chain/evm/client/client.go
+++ b/chain/evm/client/client.go
@@ -98,10 +98,9 @@ func NewClient(asset xc.ITask) (*Client, error) {
 
 	// c, err := rpc.DialContext(context.Background(), url)
 	interceptor := utils.NewHttpInterceptor(ReplaceIncompatiableEvmResponses)
-	// {http.DefaultTransport, false}
-	httpClient := &http.Client{
-		Transport: interceptor,
-	}
+
+	httpClient := asset.GetChain().DefaultHttpClient()
+	httpClient.Transport = interceptor
 	c, err := rpc.DialHTTPWithClient(url, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("dialing url: %v", nativeAsset.URL)

--- a/chain/filecoin/client/client.go
+++ b/chain/filecoin/client/client.go
@@ -52,7 +52,7 @@ func NewClient(cfgI xc.ITask) (*Client, error) {
 
 	return &Client{
 		Url:        cfg.URL,
-		HttpClient: http.DefaultClient,
+		HttpClient: cfg.DefaultHttpClient(),
 		Asset:      cfgI,
 		Logger:     logger,
 	}, nil

--- a/chain/kaspa/client/client.go
+++ b/chain/kaspa/client/client.go
@@ -47,7 +47,7 @@ func derefOrZero[T any](v *T) T {
 func NewClient(cfgI xc.ITask) (*Client, error) {
 	chain := cfgI.GetChain()
 	clientConfig := chain.ChainClientConfig
-	client := rest.NewClient(clientConfig.URL, chain.Chain)
+	client := rest.NewClient(clientConfig.URL, chain.Chain, chain.DefaultHttpClient())
 	return &Client{chain.Chain, chain, client, int(chain.Decimals)}, nil
 }
 

--- a/chain/kaspa/client/rest/client.go
+++ b/chain/kaspa/client/rest/client.go
@@ -13,13 +13,14 @@ import (
 )
 
 type Client struct {
-	url   string
-	chain xc.NativeAsset
+	url        string
+	chain      xc.NativeAsset
+	httpClient *http.Client
 }
 
-func NewClient(url string, chain xc.NativeAsset) *Client {
+func NewClient(url string, chain xc.NativeAsset, httpClient *http.Client) *Client {
 	url = strings.TrimSuffix(url, "/")
-	return &Client{url, chain}
+	return &Client{url, chain, httpClient}
 }
 
 type ErrorResponse struct {
@@ -54,7 +55,7 @@ func (cli *Client) Do(method string, path string, requestBody any, response any)
 	}
 	log := logrus.WithField("url", url).WithField("method", method)
 	log.Debug("sending request")
-	resp, err := http.DefaultClient.Do(request)
+	resp, err := cli.httpClient.Do(request)
 	if err != nil {
 		return fmt.Errorf("failed to GET: %v", err)
 	}

--- a/chain/substrate/client/api/graphql/client.go
+++ b/chain/substrate/client/api/graphql/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
@@ -37,7 +38,9 @@ func Post(ctx context.Context, url string, inputJson []byte, outputData any, arg
 		args.Limiter.Wait(ctx)
 	}
 
-	explorerClient := &http.Client{}
+	explorerClient := &http.Client{
+		Timeout: 60 * time.Second,
+	}
 	resp, err := explorerClient.Do(req)
 	if err != nil {
 		return err

--- a/chain/substrate/client/api/subscan/client.go
+++ b/chain/substrate/client/api/subscan/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
@@ -37,7 +38,9 @@ func Post(ctx context.Context, url string, inputJson []byte, outputData any, arg
 		req.Header.Add("X-API-Key", args.ApiKey)
 	}
 
-	explorerClient := &http.Client{}
+	explorerClient := &http.Client{
+		Timeout: 60 * time.Second,
+	}
 	resp, err := explorerClient.Do(req)
 	if err != nil {
 		return err

--- a/chain/substrate/client/api/taostats/client.go
+++ b/chain/substrate/client/api/taostats/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/cordialsys/crosschain/chain/substrate/client/api"
 	"github.com/sirupsen/logrus"
@@ -46,7 +47,9 @@ func (client *Client) Get(ctx context.Context, url string, outputData any) error
 	}
 	logrus.WithField("url", url).Debug("post request")
 
-	explorerClient := &http.Client{}
+	explorerClient := &http.Client{
+		Timeout: 60 * time.Second,
+	}
 	resp, err := explorerClient.Do(req)
 	if err != nil {
 		return err

--- a/chain/sui/client.go
+++ b/chain/sui/client.go
@@ -65,7 +65,7 @@ func (i *HttpLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 func NewClient(cfgI xc.ITask) (*Client, error) {
 	cfg := cfgI.GetChain()
 	httpClient := &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: cfg.DefaultHttpClient().Timeout,
 		Transport: &http.Transport{
 			MaxIdleConns:    3,
 			IdleConnTimeout: 30 * time.Second,

--- a/chain/ton/client.go
+++ b/chain/ton/client.go
@@ -108,7 +108,8 @@ func (cli *Client) send(method string, path string, requestBody any, response an
 		request.Header.Add("X-API-Key", cli.ApiKey)
 	}
 	logrus.WithField("url", url).Debug(method)
-	resp, err := http.DefaultClient.Do(request)
+	httpClient := cli.Asset.GetChain().DefaultHttpClient()
+	resp, err := httpClient.Do(request)
 	if err != nil {
 		return fmt.Errorf("failed to GET: %v", err)
 	}

--- a/chain/tron/client.go
+++ b/chain/tron/client.go
@@ -127,7 +127,7 @@ func NewClient(cfgI xc.ITask) (*Client, error) {
 		return nil, fmt.Errorf("chain gas-budget-default should be set to value greater than 0.0")
 	}
 
-	client, err := httpclient.NewHttpClient(cfg.URL)
+	client, err := httpclient.NewHttpClient(cfg.URL, cfg.DefaultHttpClient().Timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/tron/http_client/http_client.go
+++ b/chain/tron/http_client/http_client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/cordialsys/crosschain/client/errors"
 	"github.com/okx/go-wallet-sdk/crypto/base58"
@@ -166,7 +167,7 @@ type GetAccountResponse struct {
 	Address string `json:"address"`
 }
 
-func NewHttpClient(baseUrl string) (*Client, error) {
+func NewHttpClient(baseUrl string, timeout time.Duration) (*Client, error) {
 	baseUrl = strings.TrimSuffix(baseUrl, "/")
 	baseUrl = strings.TrimSuffix(baseUrl, "/wallet")
 	baseUrl = strings.TrimSuffix(baseUrl, "/jsonrpc")
@@ -174,7 +175,9 @@ func NewHttpClient(baseUrl string) (*Client, error) {
 
 	// may want to pass externally to support additional
 	// headers or something.
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: timeout,
+	}
 
 	return &Client{
 		baseUrl: u,

--- a/chain/xlm/client/client.go
+++ b/chain/xlm/client/client.go
@@ -53,7 +53,7 @@ func NewClient(cfgI xc.ITask) (*Client, error) {
 
 	return &Client{
 		Url:        cfg.URL,
-		HttpClient: http.DefaultClient,
+		HttpClient: cfg.DefaultHttpClient(),
 		Asset:      cfgI,
 	}, nil
 }

--- a/chain/xrp/client/client.go
+++ b/chain/xrp/client/client.go
@@ -33,7 +33,7 @@ func NewClient(cfgI xc.ITask) (*Client, error) {
 
 	return &Client{
 		Url:        cfg.URL,
-		HttpClient: http.DefaultClient,
+		HttpClient: cfg.DefaultHttpClient(),
 		Asset:      cfgI,
 	}, nil
 }

--- a/cmd/xc/commands/chains.go
+++ b/cmd/xc/commands/chains.go
@@ -68,7 +68,7 @@ func CmdChains() *cobra.Command {
 				logrus.Info("listing from local configuration")
 				chains := []*xc.ChainConfig{}
 				for _, chain := range xcFactory.GetAllChains() {
-					chain.Configure()
+					chain.Configure(xcFactory.Config.HttpTimeout)
 					chains = append(chains, chain)
 				}
 				err = printer(chains)

--- a/cmd/xc/commands/tools/eostools/buyram.go
+++ b/cmd/xc/commands/tools/eostools/buyram.go
@@ -87,7 +87,7 @@ func CmdTxBuyRam() *cobra.Command {
 			input := inputI.(*tx_input.TxInput)
 			input.Timestamp = time.Now().Unix()
 
-			refApi := eos.New(chainConfig.URL)
+			refApi := eos.New(chainConfig.URL, chainConfig.DefaultHttpClient().Timeout)
 			refApi.Header.Set("Content-Type", "application/json")
 
 			fromAccount := input.FromAccount

--- a/cmd/xc/commands/tools/eostools/create_account.go
+++ b/cmd/xc/commands/tools/eostools/create_account.go
@@ -101,7 +101,7 @@ func CmdTxCreateAccount() *cobra.Command {
 			input := inputI.(*tx_input.TxInput)
 			input.Timestamp = time.Now().Unix()
 
-			refApi := eos.New(chainConfig.URL)
+			refApi := eos.New(chainConfig.URL, chainConfig.HttpTimeout)
 			refApi.Header.Set("Content-Type", "application/json")
 
 			fromAccount := input.FromAccount

--- a/cmd/xc/commands/tools/eostools/stake.go
+++ b/cmd/xc/commands/tools/eostools/stake.go
@@ -93,7 +93,7 @@ func CmdTxStake() *cobra.Command {
 			input := inputI.(*tx_input.TxInput)
 			input.Timestamp = time.Now().Unix()
 
-			refApi := eos.New(chainConfig.URL)
+			refApi := eos.New(chainConfig.URL, chainConfig.HttpTimeout)
 			refApi.Header.Set("Content-Type", "application/json")
 
 			fromAccount := input.FromAccount

--- a/cmd/xc/commands/tools/eostools/transfer.go
+++ b/cmd/xc/commands/tools/eostools/transfer.go
@@ -134,7 +134,7 @@ func CmdTxTransferEOS() *cobra.Command {
 			input := inputI.(*tx_input.TxInput)
 			input.Timestamp = time.Now().Unix()
 
-			refApi := eos.New(chainConfig.URL)
+			refApi := eos.New(chainConfig.URL, chainConfig.HttpTimeout)
 			refApi.Header.Set("Content-Type", "application/json")
 
 			fromAccount := input.FromAccount

--- a/factory/config/config.go
+++ b/factory/config/config.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"time"
 
 	xc "github.com/cordialsys/crosschain"
 )
@@ -30,6 +31,7 @@ type Config struct {
 	// Default: "testnet"
 	Network       NetworkSetting `yaml:"network"`
 	CrosschainUrl string         `yaml:"crosschain_url"`
+	HttpTimeout   time.Duration  `yaml:"http_timeout"`
 
 	// map of lowercase(native_asset) -> NativeAssetObject
 	Chains map[string]*xc.ChainConfig `yaml:"chains"`
@@ -39,14 +41,14 @@ type Config struct {
 }
 
 func (cfg *Config) MigrateFields() {
-	for _, cfg := range cfg.Chains {
-		if cfg.ChainBaseConfig == nil {
-			cfg.ChainBaseConfig = &xc.ChainBaseConfig{}
+	for _, chain := range cfg.Chains {
+		if chain.ChainBaseConfig == nil {
+			chain.ChainBaseConfig = &xc.ChainBaseConfig{}
 		}
-		if cfg.ChainClientConfig == nil {
-			cfg.ChainClientConfig = &xc.ChainClientConfig{}
+		if chain.ChainClientConfig == nil {
+			chain.ChainClientConfig = &xc.ChainClientConfig{}
 		}
-		cfg.Configure()
+		chain.Configure(cfg.HttpTimeout)
 	}
 }
 

--- a/factory/defaults/chains/mainnet.yaml
+++ b/factory/defaults/chains/mainnet.yaml
@@ -9,6 +9,7 @@
 # Substrate chain prefixes can be found at https://polkadot.subscan.io/tools/format_transform
 
 network: "mainnet"
+http_timeout: 120s
 chains:
   EOS:
     chain: EOS

--- a/factory/defaults/chains/testnet.yaml
+++ b/factory/defaults/chains/testnet.yaml
@@ -1,6 +1,7 @@
 # IndexingCo IDs can be found at https://jiti.indexing.co/networks
 
 network: "testnet"
+http_timeout: 60s
 chains:
   EOS:
     chain: EOS

--- a/factory/main.go
+++ b/factory/main.go
@@ -88,7 +88,7 @@ func (f *Factory) NewClient(cfg ITask) (xclient.Client, error) {
 	url, driver := chainConfig.ClientURL()
 	switch driver {
 	case DriverCrosschain:
-		return remoteclient.NewClient(cfg, url, chainConfig.Auth2, chainConfig.CrosschainClient.Network)
+		return remoteclient.NewClient(cfg, url, chainConfig.Auth2, chainConfig.CrosschainClient.Network, f.Config.HttpTimeout)
 	default:
 		return drivers.NewClient(cfg, chainConfig.Driver)
 	}
@@ -101,7 +101,7 @@ func (f *Factory) NewStakingClient(stakingCfg *services.ServicesConfig, cfg ITas
 		network := chainConfig.CrosschainClient.Network
 		switch Driver(driver) {
 		case DriverCrosschain:
-			return remoteclient.NewStakingClient(cfg, url, chainConfig.Auth2, stakingCfg.GetApiSecret(provider), provider, network)
+			return remoteclient.NewStakingClient(cfg, url, chainConfig.Auth2, stakingCfg.GetApiSecret(provider), provider, network, f.Config.HttpTimeout)
 		}
 	}
 	return drivers.NewStakingClient(stakingCfg, cfg, provider)


### PR DESCRIPTION
In crosschain we regularly construct HTTP clients like:

```
httpClient := http.DefaultClient
```

or
```
httpClient := &http.Client{}
```
This default client never times out.

This sets a default timeout which can be overridden by normal configuration.