### PR TITLE
Implement ICP driver

### DIFF
--- a/chain/internet_computer/address/address.go
+++ b/chain/internet_computer/address/address.go
@@ -1,0 +1,76 @@
+package address
+
+import (
+	"crypto/sha256"
+	"crypto/x509/pkix"
+	"fmt"
+	"hash/crc32"
+
+	"encoding/asn1"
+	"encoding/binary"
+	"encoding/hex"
+
+	xc "github.com/cordialsys/crosschain"
+)
+
+var (
+	DefaultPrincipalSubaccount [32]byte
+)
+
+// AddressBuilder for Template
+type AddressBuilder struct {
+}
+
+var _ xc.AddressBuilder = AddressBuilder{}
+
+// NewAddressBuilder creates a new Template AddressBuilder
+func NewAddressBuilder(cfgI *xc.ChainBaseConfig) (xc.AddressBuilder, error) {
+	return AddressBuilder{}, nil
+}
+
+type publicKeyInfo struct {
+	Algorithm pkix.AlgorithmIdentifier
+	PublicKey asn1.BitString
+}
+
+// GetAddressFromPublicKey returns an Address given a public key
+func (ab AddressBuilder) GetAddressFromPublicKey(publicKeyBytes []byte) (xc.Address, error) {
+	var der, err = asn1.Marshal(publicKeyInfo{
+		Algorithm: pkix.AlgorithmIdentifier{
+			Algorithm: asn1.ObjectIdentifier{1, 3, 101, 112},
+		},
+		PublicKey: asn1.BitString{
+			BitLength: len(publicKeyBytes) * 8,
+			Bytes:     publicKeyBytes,
+		},
+	})
+	if err != nil {
+		return xc.Address(""), fmt.Errorf("failed to marshal public key: %w", err)
+	}
+
+	principal := principalFromDerPublicKey(der)
+	accountId := newAccountId(principal)
+	address := hex.EncodeToString(accountId)
+	return xc.Address(address), nil
+}
+
+func principalFromDerPublicKey(der []byte) []byte {
+	hash := sha256.Sum224(der)
+	return append(hash[:], 0x02)
+}
+
+func newAccountId(principal []byte) []byte {
+	h := sha256.New224()
+	h.Write([]byte("\x0Aaccount-id"))
+	h.Write(principal)
+	h.Write(DefaultPrincipalSubaccount[:])
+	bs := h.Sum(nil)
+
+	var accountId [28]byte
+	copy(accountId[:], bs)
+
+	crc := make([]byte, 4)
+	binary.BigEndian.PutUint32(crc, crc32.ChecksumIEEE(accountId[:]))
+
+	return append(crc, accountId[:]...)
+}

--- a/chain/internet_computer/address/address_test.go
+++ b/chain/internet_computer/address/address_test.go
@@ -1,0 +1,27 @@
+package address_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/chain/internet_computer/address"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAddressBuilder(t *testing.T) {
+	builder, err := address.NewAddressBuilder(xc.NewChainConfig("XYZ").Base())
+	require.NotNil(t, builder)
+	require.NoError(t, err)
+}
+
+func TestGetAddressFromPublicKey(t *testing.T) {
+	pk := "9fd161cd0746135f2b97626c7f630f9726cc92547eb72725dd731bcf296130a0"
+	pkBytes, err := hex.DecodeString(pk)
+	require.NoError(t, err)
+
+	builder, _ := address.NewAddressBuilder(xc.NewChainConfig("XYZ").Base())
+	address, err := builder.GetAddressFromPublicKey(pkBytes)
+	require.Equal(t, xc.Address("5227b83cc14eda8a0ce76a7f2147071e60ee3502663b0efa4e10a4add469f107"), address)
+	require.NoError(t, err)
+}

--- a/chain/internet_computer/builder/builder.go
+++ b/chain/internet_computer/builder/builder.go
@@ -1,0 +1,42 @@
+package builder
+
+import (
+	"errors"
+	"fmt"
+
+	xc "github.com/cordialsys/crosschain"
+	xcbuilder "github.com/cordialsys/crosschain/builder"
+)
+
+// TxBuilder for Template
+type TxBuilder struct {
+	Asset *xc.ChainBaseConfig
+}
+
+var _ xcbuilder.FullTransferBuilder = TxBuilder{}
+
+// NewTxBuilder creates a new Template TxBuilder
+func NewTxBuilder(cfgI *xc.ChainBaseConfig) (TxBuilder, error) {
+	return TxBuilder{
+		Asset: cfgI,
+	}, errors.New("not implemented")
+}
+
+// NewTransfer creates a new transfer for an Asset, either native or token
+func (txBuilder TxBuilder) Transfer(args xcbuilder.TransferArgs, input xc.TxInput) (xc.Tx, error) {
+	if contract, ok := args.GetContract(); ok {
+		return txBuilder.NewTokenTransfer(args, contract, input)
+	} else {
+		return txBuilder.NewNativeTransfer(args, input)
+	}
+}
+
+// NewNativeTransfer creates a new transfer for a native asset
+func (txBuilder TxBuilder) NewNativeTransfer(args xcbuilder.TransferArgs, input xc.TxInput) (xc.Tx, error) {
+	return nil, errors.New("not implemented")
+}
+
+// NewTokenTransfer creates a new transfer for a token asset
+func (txBuilder TxBuilder) NewTokenTransfer(args xcbuilder.TransferArgs, contract xc.ContractAddress, input xc.TxInput) (xc.Tx, error) {
+	return nil, fmt.Errorf("token transfers are not supported for %s", txBuilder.Asset.Chain)
+}

--- a/chain/internet_computer/builder/builder_test.go
+++ b/chain/internet_computer/builder/builder_test.go
@@ -1,0 +1,46 @@
+package builder_test
+
+import (
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/builder/buildertest"
+	"github.com/cordialsys/crosschain/chain/template/builder"
+	"github.com/cordialsys/crosschain/chain/template/tx_input"
+	"github.com/stretchr/testify/require"
+)
+
+type TxInput = tx_input.TxInput
+
+func TestNewTxBuilder(t *testing.T) {
+	builder1, err := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
+	require.NotNil(t, builder1)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestNewNativeTransfer(t *testing.T) {
+	builder, _ := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
+	from := xc.Address("from")
+	to := xc.Address("to")
+	amount := xc.AmountBlockchain{}
+	input := &TxInput{}
+	args := buildertest.MustNewTransferArgs(
+		from, to, amount,
+	)
+	_, err := builder.Transfer(args, input)
+	require.ErrorContains(t, err, "not implemented")
+}
+
+func TestNewTokenTransfer(t *testing.T) {
+	builder1, _ := builder.NewTxBuilder(xc.NewChainConfig("XYZ").Base())
+	from := xc.Address("from")
+	to := xc.Address("to")
+	amount := xc.AmountBlockchain{}
+	input := &TxInput{}
+	args := buildertest.MustNewTransferArgs(
+		from, to, amount,
+		buildertest.OptionContractAddress(xc.ContractAddress("contract")),
+	)
+	_, err := builder1.Transfer(args, input)
+	require.ErrorContains(t, err, "token transfers are not supported for XYZ")
+}

--- a/chain/internet_computer/client/client.go
+++ b/chain/internet_computer/client/client.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"context"
+	"errors"
+
+	xc "github.com/cordialsys/crosschain"
+	xcbuilder "github.com/cordialsys/crosschain/builder"
+	"github.com/cordialsys/crosschain/chain/template/tx_input"
+	xclient "github.com/cordialsys/crosschain/client"
+)
+
+// Client for Template
+type Client struct {
+}
+
+var _ xclient.Client = &Client{}
+
+// NewClient returns a new Template Client
+func NewClient(cfgI xc.ITask) (*Client, error) {
+	return &Client{}, errors.New("not implemented")
+}
+
+// FetchTransferInput returns tx input for a Template tx
+func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.TransferArgs) (xc.TxInput, error) {
+	return &tx_input.TxInput{}, errors.New("not implemented")
+}
+
+// Deprecated method - use FetchTransferInput
+func (client *Client) FetchLegacyTxInput(ctx context.Context, from xc.Address, to xc.Address) (xc.TxInput, error) {
+	// No way to pass the amount in the input using legacy interface, so we estimate using min amount.
+	args, _ := xcbuilder.NewTransferArgs(from, to, xc.NewAmountBlockchainFromUint64(1))
+	return client.FetchTransferInput(ctx, args)
+}
+
+// SubmitTx submits a Template tx
+func (client *Client) SubmitTx(ctx context.Context, txInput xc.Tx) error {
+	return errors.New("not implemented")
+}
+
+// Returns transaction info - legacy/old endpoint
+func (client *Client) FetchLegacyTxInfo(ctx context.Context, txHash xc.TxHash) (xclient.LegacyTxInfo, error) {
+	return xclient.LegacyTxInfo{}, errors.New("not implemented")
+}
+
+// Returns transaction info - new endpoint
+func (client *Client) FetchTxInfo(ctx context.Context, txHash xc.TxHash) (xclient.TxInfo, error) {
+	return xclient.TxInfo{}, errors.New("not implemented")
+}
+
+func (client *Client) FetchBalance(ctx context.Context, args *xclient.BalanceArgs) (xc.AmountBlockchain, error) {
+	return xc.AmountBlockchain{}, errors.New("not implemented")
+}
+
+func (client *Client) FetchDecimals(ctx context.Context, contract xc.ContractAddress) (int, error) {
+	return 0, errors.New("not implemented")
+}
+func (client *Client) FetchBlock(ctx context.Context, args *xclient.BlockArgs) (*xclient.BlockWithTransactions, error) {
+	return &xclient.BlockWithTransactions{}, errors.New("not implemented")
+}

--- a/chain/internet_computer/client/client_test.go
+++ b/chain/internet_computer/client/client_test.go
@@ -1,0 +1,43 @@
+package client_test
+
+import (
+	"context"
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/chain/template/client"
+	"github.com/cordialsys/crosschain/chain/template/tx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+
+	client, err := client.NewClient(xc.NewChainConfig(""))
+	require.NotNil(t, client)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestFetchTxInput(t *testing.T) {
+
+	client, _ := client.NewClient(xc.NewChainConfig(""))
+	from := xc.Address("from")
+	to := xc.Address("to")
+	input, err := client.FetchLegacyTxInput(context.Background(), from, to)
+	require.NotNil(t, input)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestSubmitTx(t *testing.T) {
+
+	client, _ := client.NewClient(xc.NewChainConfig(""))
+	err := client.SubmitTx(context.Background(), &tx.Tx{})
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestFetchTxInfo(t *testing.T) {
+
+	client, _ := client.NewClient(xc.NewChainConfig(""))
+	info, err := client.FetchLegacyTxInfo(context.Background(), xc.TxHash("hash"))
+	require.NotNil(t, info)
+	require.EqualError(t, err, "not implemented")
+}

--- a/chain/internet_computer/errors.go
+++ b/chain/internet_computer/errors.go
@@ -1,0 +1,7 @@
+package newchain
+
+import "github.com/cordialsys/crosschain/client/errors"
+
+func CheckError(err error) errors.Status {
+	return ""
+}

--- a/chain/internet_computer/tx/tx.go
+++ b/chain/internet_computer/tx/tx.go
@@ -1,0 +1,39 @@
+package tx
+
+import (
+	"errors"
+
+	xc "github.com/cordialsys/crosschain"
+)
+
+// Tx for Template
+type Tx struct {
+}
+
+var _ xc.Tx = &Tx{}
+
+// Hash returns the tx hash or id
+func (tx Tx) Hash() xc.TxHash {
+	return xc.TxHash("not implemented")
+}
+
+// Sighashes returns the tx payload to sign, aka sighash
+func (tx Tx) Sighashes() ([]*xc.SignatureRequest, error) {
+	return []*xc.SignatureRequest{}, errors.New("not implemented")
+
+}
+
+// AddSignatures adds a signature to Tx
+func (tx *Tx) AddSignatures(...*xc.SignatureResponse) error {
+	return errors.New("not implemented")
+}
+
+// GetSignatures returns back signatures, which may be used for signed-transaction broadcasting
+func (tx *Tx) GetSignatures() []xc.TxSignature {
+	return []xc.TxSignature{}
+}
+
+// Serialize returns the serialized tx
+func (tx Tx) Serialize() ([]byte, error) {
+	return []byte{}, errors.New("not implemented")
+}

--- a/chain/internet_computer/tx/tx_test.go
+++ b/chain/internet_computer/tx/tx_test.go
@@ -1,0 +1,30 @@
+package tx_test
+
+import (
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/chain/template/tx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxHash(t *testing.T) {
+
+	tx1 := tx.Tx{}
+	require.Equal(t, xc.TxHash("not implemented"), tx1.Hash())
+}
+
+func TestTxSighashes(t *testing.T) {
+
+	tx1 := tx.Tx{}
+	sighashes, err := tx1.Sighashes()
+	require.NotNil(t, sighashes)
+	require.EqualError(t, err, "not implemented")
+}
+
+func TestTxAddSignature(t *testing.T) {
+
+	tx1 := tx.Tx{}
+	err := tx1.AddSignatures([]*xc.SignatureResponse{}...)
+	require.EqualError(t, err, "not implemented")
+}

--- a/chain/internet_computer/tx_input/tx_input.go
+++ b/chain/internet_computer/tx_input/tx_input.go
@@ -1,0 +1,55 @@
+package tx_input
+
+import (
+	xc "github.com/cordialsys/crosschain"
+)
+
+// TxInput for Template
+type TxInput struct {
+	xc.TxInputEnvelope
+}
+
+var _ xc.TxInput = &TxInput{}
+
+func init() {
+	// Uncomment this line to register the driver input for serialization/derserialization
+	// registry.RegisterTxBaseInput(&TxInput{})
+}
+
+func NewTxInput() *TxInput {
+	return &TxInput{
+		TxInputEnvelope: xc.TxInputEnvelope{
+			Type: "INPUT_DRIVER_HERE",
+		},
+	}
+}
+
+func (input *TxInput) GetDriver() xc.Driver {
+	return "DRIVER HERE"
+}
+
+func (input *TxInput) SetGasFeePriority(other xc.GasFeePriority) error {
+	multiplier, err := other.GetDefault()
+	if err != nil {
+		return err
+	}
+	// multiply the gas price using the default, or apply a strategy according to the enum
+	_ = multiplier
+	return nil
+}
+
+func (input *TxInput) GetFeeLimit() (xc.AmountBlockchain, xc.ContractAddress) {
+	// get the max possible fee that could be spent on this transaction
+	return xc.NewAmountBlockchainFromUint64(0), ""
+}
+
+func (input *TxInput) IndependentOf(other xc.TxInput) (independent bool) {
+	// are these two transactions independent (e.g. different sequences & utxos & expirations?)
+	// default false
+	return
+}
+func (input *TxInput) SafeFromDoubleSend(others ...xc.TxInput) (safe bool) {
+	// safe from double send ?
+	// default false
+	return
+}

--- a/chain/internet_computer/tx_input/tx_input_test.go
+++ b/chain/internet_computer/tx_input/tx_input_test.go
@@ -1,0 +1,64 @@
+package tx_input_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	xc "github.com/cordialsys/crosschain"
+	"github.com/cordialsys/crosschain/chain/template/tx_input"
+	"github.com/stretchr/testify/require"
+)
+
+type TxInput = tx_input.TxInput
+
+func TestSafeFromDoubleSpend(t *testing.T) {
+
+	newInput := &TxInput{}
+	oldInput1 := &TxInput{}
+	// Defaults are false but each chain has conditions
+	require.False(t, newInput.SafeFromDoubleSend(oldInput1))
+	require.False(t, newInput.IndependentOf(oldInput1))
+}
+
+func TestTxInputConflicts(t *testing.T) {
+
+	type testcase struct {
+		newInput xc.TxInput
+		oldInput xc.TxInput
+
+		independent     bool
+		doubleSpendSafe bool
+	}
+	vectors := []testcase{
+		{
+			newInput:        &TxInput{},
+			oldInput:        &TxInput{},
+			independent:     false,
+			doubleSpendSafe: false,
+		},
+		{
+			newInput: &TxInput{},
+			// check no old input
+			oldInput:        nil,
+			independent:     false,
+			doubleSpendSafe: false,
+		},
+	}
+	for i, v := range vectors {
+		newBz, _ := json.Marshal(v.newInput)
+		oldBz, _ := json.Marshal(v.oldInput)
+		fmt.Printf("testcase %d - expect safe=%t, independent=%t\n     newInput = %s\n     oldInput = %s\n", i, v.doubleSpendSafe, v.independent, string(newBz), string(oldBz))
+		fmt.Println()
+		require.Equal(t,
+			v.independent,
+			v.newInput.IndependentOf(v.oldInput),
+			"IndependentOf",
+		)
+		require.Equal(t,
+			v.doubleSpendSafe,
+			v.newInput.SafeFromDoubleSend(v.oldInput),
+			"SafeFromDoubleSend",
+		)
+	}
+}


### PR DESCRIPTION
This MR adds Internet Computer Protocol driver - native transactions only.

ICP supports both Ed25519 and Secpk256k, however I implemented only Ed25519 support for now. Extending that shouldn't be an issue in the future.

Good reads related to ICP:
- [HTTPS interface](https://internetcomputer.org/docs/references/ic-interface-spec/#http-interface)
- [Auth](https://internetcomputer.org/docs/references/ic-interface-spec/#authentication)
- [GAS Model](https://internetcomputer.org/docs/building-apps/essentials/gas-cost/#the-reverse-gas-model)
- [Token transfers](https://internetcomputer.org/docs/references/samples/rust/token_transfer/)