### PR TITLE
megaeth: add initial support

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -82,6 +82,7 @@ const (
 	KLAY     = NativeAsset("KLAY")     // Klaytn
 	KSM      = NativeAsset("KSM")      // Kusama
 	MATIC    = NativeAsset("MATIC")    // Polygon
+	MegaETH  = NativeAsset("MegaETH")  // MegaETH
 	MON      = NativeAsset("MON")      // MONAD
 	NEAR     = NativeAsset("NEAR")     // Near
 	NOBLE    = NativeAsset("NOBLE")    // Noble Chain
@@ -163,6 +164,7 @@ var NativeAssetList []NativeAsset = []NativeAsset{
 	KSM,
 	XDC,
 	MATIC,
+	MegaETH,
 	MON,
 	NEAR,
 	OAS,
@@ -329,7 +331,7 @@ func (native NativeAsset) Driver() Driver {
 		return DriverBitcoinLegacy
 	case ZEC, FLUX:
 		return DriverZcash
-	case AVAX, BNB, CELO, ETH, ETHW, GUSDT, MATIC, OptETH, ArbETH, BERA, BASE, SeiEVM, MON, HyperEVM, LinETH, XPL, ZeroG, TEMPO, FRAX:
+	case AVAX, BNB, CELO, ETH, ETHW, GUSDT, MATIC, OptETH, ArbETH, BERA, BASE, SeiEVM, MegaETH, MON, HyperEVM, LinETH, XPL, ZeroG, TEMPO, FRAX:
 		return DriverEVM
 	case FTM, ETC, EmROSE, AurETH, ACA, KLAY, OAS, CHZ, XDC, CHZ2:
 		return DriverEVMLegacy

--- a/factory/defaults/chains/mainnet.yaml
+++ b/factory/defaults/chains/mainnet.yaml
@@ -1224,6 +1224,36 @@ chains:
         asset_id: polygon-pos
       indexing_co:
         chain_id: polygon
+  MegaETH:
+    chain: MegaETH
+    support:
+      call: true
+      fee:
+        accurate: true
+        payer: true
+    driver: evm
+    chain_id: 4326
+    chain_name: MegaETH
+    decimals: 18
+    fee_limit: "5.0"
+    confirmations_final: 30
+    native_assets:
+      - asset_id: "MegaETH"
+        decimals: 18
+        bridged_asset: "chains/ETH/assets/ETH" # MegaETH is settled in ETH
+    explorer_urls:
+      tx: "https://mega.etherscan.io/tx/{}"
+      address: "https://mega.etherscan.io/address/{}"
+      token: "https://mega.etherscan.io/token/{}"
+    external:
+      coin_gecko:
+        chain_id: megaeth
+        asset_id: "megaeth"
+      coin_market_cap:
+        chain_id: "278"
+        asset_id: "38770"
+      indexing_co:
+        chain_id: megaeth
   MON:
     chain: MON
     support:

--- a/factory/defaults/chains/testnet.yaml
+++ b/factory/defaults/chains/testnet.yaml
@@ -600,6 +600,21 @@ chains:
     chain_id: 80001
     chain_name: Polygon (Mumbai)
     decimals: 18
+  MegaETH:
+    chain: MegaETH
+    support:
+      call: true
+      fee:
+        accurate: true
+        payer: true
+    driver: evm
+    chain_id: 6343
+    chain_name: MegaETH Testnet
+    decimals: 18
+    explorer_urls:
+      tx: "https://megaeth-testnet-v2.blockscout.com/tx/{}"
+      address: "https://megaeth-testnet-v2.blockscout.com/address/{}"
+      token: "https://megaeth-testnet-v2.blockscout.com/token/{}"
   MON:
     chain: MON
     support:


### PR DESCRIPTION
## Summary
- Adds `MegaETH` as a new EVM-driver chain (mainnet chain id 4326, testnet 6343).
- Native asset bridges to ETH (settled L2). Public RPC defaults can be overridden via the connector config in services.

## Test plan
- [x] `go test -mod=readonly -tags not_ci ./...` passes
- [ ] Manual `xc address --chain MegaETH` / `xc balance ... --chain MegaETH` against testnet RPC
- [ ] Manual transfer test on testnet using connector config

Companion: cordialsys/services PR adds MegaETH RPC + oracle entries.