### PR TITLE
xrp: fix inclusive-fee sweeps when account-delete is not allowed

### DIFF
--- a/chain/xrp/client/client.go
+++ b/chain/xrp/client/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	xc "github.com/cordialsys/crosschain"
@@ -55,10 +56,39 @@ func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.Tra
 	txInput.V2Sequence = currentSequencePtr
 
 	txInput.XrpBalance = xc.NewAmountBlockchainFromStr(accountInfo.Result.AccountData.Balance)
-	// Currently the reserve amount is 1XRP and the delete-account fee is 0.2XRP
-	// We'll use the 0.2 as the threshold for account deletion.
-	txInput.AccountDeleteFee = xc.NewAmountBlockchainFromUint64(200_000)
-	txInput.ReserveAmount = xc.NewAmountBlockchainFromUint64(200_000)
+
+	// Query the network's current reserve values.  reserve_base_xrp is the
+	// minimum balance an account must hold; reserve_inc_xrp is the per-object
+	// reserve and is also the fee burned by an AccountDelete transaction.
+	// These values change occasionally (e.g. mainnet has reduced its base
+	// reserve several times) so it is unsafe to hardcode them.
+	const xrpDecimals = types.XRP_NATIVE_DECIMALS
+	if serverInfo, err := client.getServerInfo(); err == nil {
+		ledger := serverInfo.Result.Info.ValidatedLedger
+		if ledger.ReserveBaseXRP > 0 {
+			reserveHuman, err := xc.NewAmountHumanReadableFromStr(strconv.FormatFloat(ledger.ReserveBaseXRP, 'f', -1, 64))
+			if err == nil {
+				txInput.ReserveAmount = reserveHuman.ToBlockchain(xrpDecimals)
+			}
+		}
+		if ledger.ReserveIncXRP > 0 {
+			feeHuman, err := xc.NewAmountHumanReadableFromStr(strconv.FormatFloat(ledger.ReserveIncXRP, 'f', -1, 64))
+			if err == nil {
+				txInput.AccountDeleteFee = feeHuman.ToBlockchain(xrpDecimals)
+			}
+		}
+	} else {
+		logrus.WithError(err).Debug("server_info failed; falling back to default XRP reserves")
+	}
+	if txInput.AccountDeleteFee.IsZero() {
+		// Pre-July-2024 mainnet default; safe lower bound on most networks.
+		txInput.AccountDeleteFee = xc.NewAmountBlockchainFromUint64(200_000)
+	}
+	if txInput.ReserveAmount.IsZero() {
+		txInput.ReserveAmount = xc.NewAmountBlockchainFromUint64(1_000_000)
+	}
+	// Allow the chain config to override the base reserve (kept for backwards
+	// compatibility with operators that hardcode this value).
 	reserveAmountHuman := client.Asset.GetChain().ChainClientConfig.ReserveAmount
 	if !reserveAmountHuman.IsZero() {
 		reserveAmount := reserveAmountHuman.ToBlockchain(client.Asset.GetChain().GetDecimals())
@@ -98,14 +128,6 @@ func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.Tra
 			tfAmount.ToHuman(decimals),
 		)
 	}
-	if remainder.Cmp(&txInput.ReserveAmount) <= 0 {
-		logrus.WithFields(logrus.Fields{
-			"balance": txInput.XrpBalance,
-			"reserve": txInput.ReserveAmount,
-			"amount":  tfAmount,
-		}).Debug("XRP balance is less than reserve amount, setting account delete")
-		txInput.AccountDelete = true
-	}
 
 	ledger, err := client.getLatestLedger(false)
 	if err != nil {
@@ -115,6 +137,36 @@ func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.Tra
 	ledgerOffset := int64(20) // Ledger offset
 	lastLedgerSequence := ledgerSequencePtr + ledgerOffset
 	txInput.V2LastLedgerSequence = lastLedgerSequence
+
+	if remainder.Cmp(&txInput.ReserveAmount) <= 0 {
+		// The user is trying to send (almost) their entire balance.  XRP requires
+		// that a base-reserve remain in the account; the only way to release it
+		// is via an AccountDelete transaction.  AccountDelete itself has two
+		// on-chain preconditions:
+		//   - the account must own no ledger objects (OwnerCount == 0)
+		//   - the account's Sequence + 256 must be less than the current ledger
+		//     index (otherwise rippled returns tecTOO_SOON)
+		// If either precondition fails, fall back to a regular Payment that
+		// leaves the reserve in place.  Inclusive-fee spending will then deduct
+		// the reserve in addition to the network fee (see GetFeeLimit).
+		ownerCount := accountInfo.Result.AccountData.OwnerCount
+		canAccountDelete := ownerCount == 0 && ledgerSequencePtr > txInput.V2Sequence+256
+		log := logrus.WithFields(logrus.Fields{
+			"balance":        txInput.XrpBalance,
+			"reserve":        txInput.ReserveAmount,
+			"amount":         tfAmount,
+			"owner_count":    ownerCount,
+			"sequence":       txInput.V2Sequence,
+			"current_ledger": ledgerSequencePtr,
+		})
+		if canAccountDelete {
+			log.Debug("XRP balance is less than reserve amount, using account-delete to sweep")
+			txInput.AccountDelete = true
+		} else {
+			log.Debug("XRP balance is less than reserve amount but account-delete is not yet allowed; reserve must remain in account")
+			txInput.MustReserve = true
+		}
+	}
 
 	feeInfo, err := client.getFee()
 	if err != nil {

--- a/chain/xrp/client/client_test.go
+++ b/chain/xrp/client/client_test.go
@@ -36,6 +36,20 @@ func TestFetchTxInput(t *testing.T) {
 	to := xc.Address("rs2x5gvFupB22myz86BUu7m5F4YuizsFna")
 	asset := xc.NewChainConfig(xc.XRP).WithDecimals(types.XRP_NATIVE_DECIMALS)
 
+	// All test cases share the same server_info response: 1 XRP base reserve and
+	// 0.2 XRP per-object reserve (which is also the AccountDelete fee).
+	serverInfoResp := types.ServerInfoResponse{
+		Result: types.ServerInfoResult{
+			Info: types.ServerInfo{
+				ValidatedLedger: types.ValidatedLedgerInfo{
+					BaseFeeXRP:     0.00001,
+					ReserveBaseXRP: 1.0,
+					ReserveIncXRP:  0.2,
+				},
+			},
+		},
+	}
+
 	vectors := []struct {
 		name string
 		args xcbuilder.TransferArgs
@@ -77,7 +91,7 @@ func TestFetchTxInput(t *testing.T) {
 				V2Sequence:           861823,
 				V2LastLedgerSequence: 1221021,
 				Fee:                  xc.NewAmountBlockchainFromUint64(100),
-				ReserveAmount:        xc.NewAmountBlockchainFromUint64(200_000),
+				ReserveAmount:        xc.NewAmountBlockchainFromUint64(1_000_000),
 				AccountDeleteFee:     xc.NewAmountBlockchainFromUint64(200_000),
 				XrpBalance:           xc.NewAmountBlockchainFromStr("10000000"),
 			},
@@ -113,7 +127,7 @@ func TestFetchTxInput(t *testing.T) {
 				V2Sequence:           0,
 				V2LastLedgerSequence: 1221021,
 				Fee:                  xc.NewAmountBlockchainFromUint64(10),
-				ReserveAmount:        xc.NewAmountBlockchainFromUint64(200_000),
+				ReserveAmount:        xc.NewAmountBlockchainFromUint64(1_000_000),
 				AccountDeleteFee:     xc.NewAmountBlockchainFromUint64(200_000),
 				XrpBalance:           xc.NewAmountBlockchainFromStr("10000000"),
 			},
@@ -147,7 +161,7 @@ func TestFetchTxInput(t *testing.T) {
 				V2Sequence:           861823,
 				V2LastLedgerSequence: 20,
 				Fee:                  xc.NewAmountBlockchainFromUint64(100),
-				ReserveAmount:        xc.NewAmountBlockchainFromUint64(200_000),
+				ReserveAmount:        xc.NewAmountBlockchainFromUint64(1_000_000),
 				AccountDeleteFee:     xc.NewAmountBlockchainFromUint64(200_000),
 				XrpBalance:           xc.NewAmountBlockchainFromStr("10000000"),
 			},
@@ -173,19 +187,97 @@ func TestFetchTxInput(t *testing.T) {
 				},
 			},
 			ledgerResp: types.LedgerResponse{
-				Result: types.LedgerResult{},
+				// Account-delete requires Sequence + 256 < current ledger.
+				Result: types.LedgerResult{LedgerCurrentIndex: 862080},
 			},
 			expectedTxInput: xrptxinput.TxInput{
 				TxInputEnvelope: xc.TxInputEnvelope{
 					Type: "xrp",
 				},
 				V2Sequence:           861823,
-				V2LastLedgerSequence: 20,
+				V2LastLedgerSequence: 862100,
 				Fee:                  xc.NewAmountBlockchainFromUint64(100),
-				ReserveAmount:        xc.NewAmountBlockchainFromUint64(200_000),
+				ReserveAmount:        xc.NewAmountBlockchainFromUint64(1_000_000),
 				AccountDeleteFee:     xc.NewAmountBlockchainFromUint64(200_000),
 				XrpBalance:           xc.NewAmountBlockchainFromStr("10000000"),
 				AccountDelete:        true,
+			},
+		},
+		{
+			name: "must reserve when account-delete is too soon",
+			// Same as the account-delete case but the account is too young: Sequence + 256
+			// is not yet less than the current ledger index, so account-delete would fail
+			// on chain with tecTOO_SOON.  The reserve must stay in the account.
+			args: buildertest.MustNewTransferArgs(asset.Base(), from, to, xc.NewAmountBlockchainFromUint64(10000000-200_000)),
+			accountInfoResp: types.AccountInfoResponse{
+				Result: types.AccountInfoResultDetails{
+					AccountData: types.AccountData{
+						Sequence: 861823,
+						Balance:  "10000000",
+					},
+				},
+			},
+			feeResp: types.FeeResponse{
+				Result: types.FeeResult{
+					Drops: types.FeeDrops{
+						BaseFee:   xc.NewAmountBlockchainFromUint64(10),
+						MedianFee: xc.NewAmountBlockchainFromUint64(100),
+					},
+				},
+			},
+			ledgerResp: types.LedgerResponse{
+				// Sequence + 256 = 862079, current ledger = 862000 -> too soon.
+				Result: types.LedgerResult{LedgerCurrentIndex: 862000},
+			},
+			expectedTxInput: xrptxinput.TxInput{
+				TxInputEnvelope: xc.TxInputEnvelope{
+					Type: "xrp",
+				},
+				V2Sequence:           861823,
+				V2LastLedgerSequence: 862020,
+				Fee:                  xc.NewAmountBlockchainFromUint64(100),
+				ReserveAmount:        xc.NewAmountBlockchainFromUint64(1_000_000),
+				AccountDeleteFee:     xc.NewAmountBlockchainFromUint64(200_000),
+				XrpBalance:           xc.NewAmountBlockchainFromStr("10000000"),
+				MustReserve:          true,
+			},
+		},
+		{
+			name: "must reserve when account owns objects",
+			// Account has trustlines or other owned objects, so account-delete is impossible.
+			args: buildertest.MustNewTransferArgs(asset.Base(), from, to, xc.NewAmountBlockchainFromUint64(10000000-200_000)),
+			accountInfoResp: types.AccountInfoResponse{
+				Result: types.AccountInfoResultDetails{
+					AccountData: types.AccountData{
+						Sequence:   861823,
+						Balance:    "10000000",
+						OwnerCount: 1,
+					},
+				},
+			},
+			feeResp: types.FeeResponse{
+				Result: types.FeeResult{
+					Drops: types.FeeDrops{
+						BaseFee:   xc.NewAmountBlockchainFromUint64(10),
+						MedianFee: xc.NewAmountBlockchainFromUint64(100),
+					},
+				},
+			},
+			ledgerResp: types.LedgerResponse{
+				// Old enough by sequence, but OwnerCount > 0 still blocks account-delete.
+				Result: types.LedgerResult{LedgerCurrentIndex: 862080},
+			},
+			expectedTxInput: xrptxinput.TxInput{
+				TxInputEnvelope: xc.TxInputEnvelope{
+					Type: "xrp",
+				},
+				V2Sequence:           861823,
+				V2LastLedgerSequence: 862100,
+				Fee:                  xc.NewAmountBlockchainFromUint64(100),
+				ReserveAmount:        xc.NewAmountBlockchainFromUint64(1_000_000),
+				AccountDeleteFee:     xc.NewAmountBlockchainFromUint64(200_000),
+				XrpBalance:           xc.NewAmountBlockchainFromStr("10000000"),
+				MustReserve:          true,
 			},
 		},
 		{
@@ -218,7 +310,7 @@ func TestFetchTxInput(t *testing.T) {
 				V2Sequence:           861823,
 				V2LastLedgerSequence: 20,
 				Fee:                  xc.NewAmountBlockchainFromUint64(100),
-				ReserveAmount:        xc.NewAmountBlockchainFromUint64(200_000),
+				ReserveAmount:        xc.NewAmountBlockchainFromUint64(1_000_000),
 				AccountDeleteFee:     xc.NewAmountBlockchainFromUint64(200_000),
 				XrpBalance:           xc.NewAmountBlockchainFromStr("10000000"),
 				AccountDelete:        true,
@@ -244,6 +336,9 @@ func TestFetchTxInput(t *testing.T) {
 				require.NoError(t, err)
 			} else if method == "fee" {
 				err := json.NewEncoder(w).Encode(vector.feeResp)
+				require.NoError(t, err)
+			} else if method == "server_info" {
+				err := json.NewEncoder(w).Encode(serverInfoResp)
 				require.NoError(t, err)
 			} else {
 				t.Errorf("unexpected method: %s", method)

--- a/chain/xrp/client/rpc.go
+++ b/chain/xrp/client/rpc.go
@@ -186,3 +186,17 @@ func (client *Client) getFee() (*types.FeeResponse, error) {
 
 	return &submitResponse, nil
 }
+
+func (client *Client) getServerInfo() (*types.ServerInfoResponse, error) {
+	request := &types.ServerInfoRequest{
+		Method: "server_info",
+		Params: []types.ServerInfoParams{{}},
+	}
+
+	var response types.ServerInfoResponse
+	err := client.Send(MethodPost, request, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/chain/xrp/client/types/fee.go
+++ b/chain/xrp/client/types/fee.go
@@ -40,3 +40,34 @@ type FeeLevels struct {
 	OpenLedgerLevel xc.AmountBlockchain `json:"open_ledger_level"`
 	ReferenceLevel  xc.AmountBlockchain `json:"reference_level"`
 }
+
+// ServerInfoRequest is used to query the rippled `server_info` endpoint.  We
+// use it to read the network's current base reserve and per-object reserve,
+// which determine when AccountDelete is required to sweep an account and how
+// much is burned by the AccountDelete itself.
+type ServerInfoRequest struct {
+	Method string             `json:"method"`
+	Params []ServerInfoParams `json:"params"`
+}
+
+type ServerInfoParams struct{}
+
+type ServerInfoResponse struct {
+	Result ServerInfoResult `json:"result"`
+}
+
+type ServerInfoResult struct {
+	Info ServerInfo `json:"info"`
+}
+
+type ServerInfo struct {
+	ValidatedLedger ValidatedLedgerInfo `json:"validated_ledger"`
+}
+
+// XRP-denominated reserves (e.g. 1.0, 0.2). Convert to drops by multiplying
+// by 1_000_000 (XRP_NATIVE_DECIMALS).
+type ValidatedLedgerInfo struct {
+	BaseFeeXRP     float64 `json:"base_fee_xrp"`
+	ReserveBaseXRP float64 `json:"reserve_base_xrp"`
+	ReserveIncXRP  float64 `json:"reserve_inc_xrp"`
+}

--- a/chain/xrp/tx_input/tx_input.go
+++ b/chain/xrp/tx_input/tx_input.go
@@ -18,6 +18,11 @@ type TxInput struct {
 	XrpBalance           xc.AmountBlockchain `json:"xrp_balance,omitempty"`
 	// Indicate if account-delete is needed to send the full amount requested
 	AccountDelete bool `json:"account_delete,omitempty"`
+	// MustReserve is set when the sender wants to send (almost) the full balance but
+	// the account is ineligible for AccountDelete (account too new, or has owned objects).
+	// In that case the network reserve must remain in the account, so inclusive-fee
+	// spending must deduct the reserve in addition to the regular network fee.
+	MustReserve bool `json:"must_reserve,omitempty"`
 	// NeedsCreateTrustline indicates that the sender needs a trustline for the token asset.
 	// When true, a TrustSet transaction is built instead of Payment.
 	NeedsCreateTrustline bool `json:"should_create_trustline,omitempty"`
@@ -54,7 +59,11 @@ func (input *TxInput) SetGasFeePriority(other xc.GasFeePriority) error {
 
 func (input *TxInput) GetFeeLimit() (xc.AmountBlockchain, xc.ContractAddress) {
 	if input.AccountDelete {
-		return input.ReserveAmount, ""
+		return input.AccountDeleteFee, ""
+	}
+	if input.MustReserve {
+		total := input.Fee.Add(&input.ReserveAmount)
+		return total, ""
 	}
 	return input.Fee, ""
 }


### PR DESCRIPTION
## Summary

When a user attempts a sweep (full-balance) inclusive-fee transfer on XRP, the client unconditionally switches to an `AccountDelete` transaction whenever the remainder ≤ network reserve. That ignored the two on-chain preconditions for `AccountDelete`, causing the transaction to fail at submission:

- The account must own no ledger objects (`OwnerCount == 0`)
- The account's `Sequence + 256` must be less than the current ledger index, otherwise rippled returns `tecTOO_SOON`

Sweeps from recently-funded accounts and from any account holding trustlines or other objects therefore failed.

This PR:
- Checks both `AccountDelete` preconditions before opting in. When they don't hold, sets a new `MustReserve` flag so inclusive-fee spending deducts the base reserve in addition to the network fee — the resulting Payment leaves the reserve intact and succeeds.
- Reads the network's actual `reserve_base_xrp` and `reserve_inc_xrp` from `server_info` rather than hardcoding 0.2 XRP for both. The base reserve has historically been higher than the per-object reserve (currently 1 XRP vs 0.2 XRP on testnet/mainnet), and hardcoding the same value picks the wrong AccountDelete threshold.
- Returns `AccountDeleteFee` (the actual fee burned) from `GetFeeLimit` for the AccountDelete path instead of `ReserveAmount`, so the inclusive-fee deduction matches the on-chain effect once the two values diverge.

## Reproduction (before the fix)

```
$ xc transfer <dest> 100.795 --chain XRP --inclusive-fee --rpc <testnet rpc>
deducting fee from amount: fee=0.2 new_amount=100.595 original_amount=100.795
Error: transaction not accepted: It is too early to attempt the requested operation. Please wait. (tecTOO_SOON)
```

## Test plan
- [x] `go test ./chain/xrp/...` — added two new test cases covering the must-reserve fallback (account-too-young and account-with-objects), and updated the existing account-delete test to cover the sequence/ledger gating.
- [x] Full suite: `go test -tags not_ci ./...` passes.
- [x] Manual end-to-end on XRP testnet:
  - Partial inclusive-fee transfer (5 XRP): succeeds, recipient gets `5 - tx_fee`.
  - Sweep with AccountDelete allowed: succeeds, recipient gets `balance - account_delete_fee`, account is deleted.
  - Sweep on a freshly-funded account (account-delete blocked by `Sequence + 256 ≥ current ledger`): now succeeds via the `MustReserve` fallback. Recipient gets `balance - reserve - tx_fee`; account left with exactly the 1 XRP base reserve.