### PR TITLE
xlm: fix inclusive-fee transfers and sweeps

### DIFF
--- a/chain/xlm/builder/builder.go
+++ b/chain/xlm/builder/builder.go
@@ -164,6 +164,28 @@ func (builder TxBuilder) Transfer(args xcbuilder.TransferArgs, input xc.TxInput)
 					Body:          xdrOperationBody,
 				})
 			}
+		} else if !isToken && txInput.AccountMerge && args.InclusiveFeeSpendingEnabled() {
+			// Sweep transfer: merge the source account into the destination.
+			// AccountMerge only operates on the native asset, so we require
+			// !isToken here in addition to the AccountMerge flag itself — that
+			// way a stray flag on a token transfer cannot accidentally drain
+			// the sender's XLM balance. AccountMerge releases the network
+			// reserve and transfers the entire remaining XLM balance, so the
+			// on-chain effect matches a true "send all". Guarded with
+			// InclusiveFeeSpendingEnabled so callers that did not opt in to
+			// inclusive-fee never see their amount silently replaced.
+			destinationMuxedAccount, err := common.MuxedAccountFromAddress(to)
+			if err != nil {
+				return &xlmtx.Tx{}, fmt.Errorf("invalid `to` address for merge: %w", err)
+			}
+			mergeBody, err := xdr.NewOperationBody(xdr.OperationTypeAccountMerge, destinationMuxedAccount)
+			if err != nil {
+				return &xlmtx.Tx{}, fmt.Errorf("failed to create account-merge operation: %w", err)
+			}
+			operations = append(operations, xdr.Operation{
+				SourceAccount: &opSourceAccount,
+				Body:          mergeBody,
+			})
 		} else {
 			// Use Payment for funded accounts or token transfers
 			destinationMuxedAccount, err := common.MuxedAccountFromAddress(to)

--- a/chain/xlm/builder/builder_test.go
+++ b/chain/xlm/builder/builder_test.go
@@ -50,6 +50,57 @@ func TestNewNativeTransfer(t *testing.T) {
 	require.Equal(t, int64(payment.Amount), amount.Int().Int64())
 }
 
+func TestAccountMergeSweep(t *testing.T) {
+	chain := xc.NewChainConfig(xc.XLM)
+	txBuilder, _ := builder.NewTxBuilder(chain.Base())
+	from := xc.Address("GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H")
+	to := xc.Address("GCITKPHEIYPB743IM4DYB23IOZIRBAQ76J6QNKPPXVI2N575JZ3Z65DI")
+	amount := xc.NewAmountBlockchainFromUint64(20_000_000)
+	input := &tx_input.TxInput{
+		DestinationFunded: true,
+		AccountMerge:      true,
+		MaxFee:            100,
+	}
+	args := buildertest.MustNewTransferArgs(
+		chain.Base(), from, to, amount,
+		buildertest.OptionInclusiveFeeSpending(true),
+	)
+	nt, err := txBuilder.Transfer(args, input)
+	require.NoError(t, err)
+	require.NotNil(t, nt)
+
+	txEnvelope := nt.(*Tx).TxEnvelope
+	op := txEnvelope.Operations()[0]
+	require.Equal(t, xdr.OperationTypeAccountMerge, op.Body.Type)
+	mergeDest, ok := op.Body.GetDestination()
+	require.True(t, ok)
+	require.Equal(t, string(to), mergeDest.Address())
+
+	// Without inclusive-fee spending the builder must fall back to a Payment
+	// so callers that did not opt in cannot accidentally have their amount
+	// replaced by a full-balance merge.
+	argsNoInclusive := buildertest.MustNewTransferArgs(chain.Base(), from, to, amount)
+	nt2, err := txBuilder.Transfer(argsNoInclusive, input)
+	require.NoError(t, err)
+	_, isPayment := nt2.(*Tx).TxEnvelope.Operations()[0].Body.GetPaymentOp()
+	require.True(t, isPayment)
+
+	// And if AccountMerge is somehow set on a token transfer the builder must
+	// still emit a regular token Payment — AccountMerge only operates on the
+	// native asset, so honouring the flag would silently drain the sender's
+	// XLM instead of moving the requested token.
+	argsToken := buildertest.MustNewTransferArgs(
+		chain.Base(), from, to, amount,
+		buildertest.OptionContractAddress("USDC-GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"),
+		buildertest.OptionInclusiveFeeSpending(true),
+	)
+	nt3, err := txBuilder.Transfer(argsToken, input)
+	require.NoError(t, err)
+	payment, isPayment := nt3.(*Tx).TxEnvelope.Operations()[0].Body.GetPaymentOp()
+	require.True(t, isPayment)
+	require.Equal(t, xdr.AssetTypeAssetTypeCreditAlphanum4, payment.Asset.Type)
+}
+
 func TestNewNativeTransferToNewAccount(t *testing.T) {
 	chain := xc.NewChainConfig(xc.XLM)
 	txBuilder, _ := builder.NewTxBuilder(chain.Base())

--- a/chain/xlm/client/client.go
+++ b/chain/xlm/client/client.go
@@ -83,6 +83,17 @@ func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.Tra
 		return nil, fmt.Errorf("failed to fetch ledger info: %w", err)
 	}
 
+	// Defaults for Stellar mainnet/testnet today; the network reports current
+	// values via /ledgers (base_fee_in_stroops / base_reserve_in_stroops).
+	baseFee := uint32(100)
+	baseReserve := int64(5_000_000)
+	if ledger.BaseFeeInStroops > 0 {
+		baseFee = uint32(ledger.BaseFeeInStroops)
+	}
+	if ledger.BaseReserveInStroops > 0 {
+		baseReserve = ledger.BaseReserveInStroops
+	}
+
 	nextSequence := currentSequence + 1
 	txInput.Sequence = integer.Int64(nextSequence)
 	txInput.SequenceOld = nextSequence
@@ -161,28 +172,26 @@ func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.Tra
 		return nil, fmt.Errorf("failed to read native balance: %w", err)
 	}
 
-	// Validate the amount and deduct it from the sender's balance if the input
-	// pertains to a native transaction (only when sender pays fees)
+	// Validate the amount when the sender pays fees in the native asset. We
+	// intentionally do NOT subtract the amount from the balance before
+	// computing MaxFee; doing so caused MaxFee to collapse to 0 for sweep
+	// transfers and the submission to fail with tx_insufficient_fee.
 	if !hasFeePayer {
 		if _, ok := args.GetContract(); !ok {
 			amount := args.GetAmount()
 			if feeAccountBalance.Cmp(&amount) == -1 {
 				return nil, fmt.Errorf("failed to create tx input, tx amount(%s) greater than balance(%s)", amount.String(), feeAccountBalance.String())
 			}
-			feeAccountBalance = feeAccountBalance.Sub(&amount)
 		}
 	}
 
-	// Set MaxFee (inclusion fee).
-	// For Soroban transactions, MaxFee may already be set from fee stats — only override
-	// with the gas budget default if it hasn't been set yet.
+	// Set MaxFee to the inclusion fee the network will actually charge
+	// (base_fee * num_operations, mirroring the operation branches in the
+	// builder). ChainGasMultiplier below adds headroom for fee surges.
+	// For Soroban transactions MaxFee may already be set from fee stats —
+	// leave that path alone.
 	if txInput.MaxFee == 0 {
-		maxFee := config.GasBudgetDefault.ToBlockchain(config.Decimals)
-		if feeAccountBalance.Cmp(&maxFee) > 0 {
-			txInput.MaxFee = uint32(maxFee.Uint64())
-		} else {
-			txInput.MaxFee = uint32(feeAccountBalance.Uint64())
-		}
+		txInput.MaxFee = baseFee * countOperations(args, txInput)
 	}
 
 	// Apply chain gas-price multiplier to fees if configured.
@@ -194,7 +203,71 @@ func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.Tra
 		}
 	}
 
+	// Sweep handling for native XLM payments when the sender pays its own fees.
+	// Stellar accounts must keep at least (2 + subentry_count) * base_reserve
+	// in their balance; trying to send the entire balance otherwise fails with
+	// tx_insufficient_balance. If the destination is funded and the sender
+	// has no subentries, an AccountMerge releases the reserve entirely;
+	// otherwise the reserve must remain in the account and inclusive-fee
+	// spending needs to deduct it in addition to the network fee.
+	if !hasFeePayer {
+		if _, isToken := args.GetContract(); !isToken && !common.IsContractAddress(args.GetTo()) {
+			subentries := int64(accountDetails.SubentryCount)
+			minBalance := xc.NewAmountBlockchainFromUint64(uint64((2 + subentries) * baseReserve))
+
+			amount := args.GetAmount()
+			actualFee := xc.NewAmountBlockchainFromUint64(uint64(txInput.MaxFee))
+			remainder := feeAccountBalance.Sub(&amount)
+			feeAndReserve := actualFee.Add(&minBalance)
+
+			if remainder.Cmp(&feeAndReserve) < 0 {
+				if txInput.DestinationFunded && subentries == 0 {
+					logrus.WithFields(logrus.Fields{
+						"balance":     feeAccountBalance,
+						"amount":      amount,
+						"min_balance": minBalance,
+						"fee":         actualFee,
+					}).Debug("XLM sweep: using account-merge to release the reserve")
+					txInput.AccountMerge = true
+				} else {
+					logrus.WithFields(logrus.Fields{
+						"balance":            feeAccountBalance,
+						"amount":             amount,
+						"min_balance":        minBalance,
+						"fee":                actualFee,
+						"subentry_count":     subentries,
+						"destination_funded": txInput.DestinationFunded,
+					}).Debug("XLM sweep: account is ineligible for merge; reserve must remain in account")
+					// MinBalance is only consumed by GetFeeLimit in the
+					// MustReserve branch, so set it only here.
+					txInput.MustReserve = true
+					txInput.MinBalance = minBalance
+				}
+			}
+		}
+	}
+
 	return txInput, nil
+}
+
+// countOperations mirrors the branches in chain/xlm/builder/builder.go so the
+// inclusion fee (base_fee * num_operations) can be computed without building
+// the tx. Soroban paths return 1; resource fees are tracked separately.
+func countOperations(args xcbuilder.TransferArgs, txInput *xlminput.TxInput) uint32 {
+	var ops uint32
+	if txInput.NeedsCreateTrustline {
+		ops++
+	}
+	// The builder skips the payment op when amount is zero (trustline-only).
+	amount := args.GetAmount()
+	zero := xc.NewAmountBlockchainFromUint64(0)
+	if amount.Cmp(&zero) > 0 || !txInput.NeedsCreateTrustline {
+		ops++
+	}
+	if ops == 0 {
+		ops = 1
+	}
+	return ops
 }
 
 // Deprecated method - use FetchTransferInput

--- a/chain/xlm/client/client_test.go
+++ b/chain/xlm/client/client_test.go
@@ -141,7 +141,9 @@ func TestFetchTxInput(t *testing.T) {
 				TxInputEnvelope: xc.TxInputEnvelope{Type: "xlm"},
 				SequenceOld:     1213,
 				Sequence:        integer.Int64(1213),
-				MaxFee:          100,
+				// MaxFee = base_fee * num_operations = 100 * 1 = 100 stroops.
+				// Not a sweep, so MinBalance is left zero.
+				MaxFee: 100,
 				// 2h * nanoseconds (10^9)
 				TransactionActiveTime: time.Duration(7200 * 1e9),
 				MinLedgerSequence:     1111,
@@ -150,7 +152,7 @@ func TestFetchTxInput(t *testing.T) {
 			},
 		},
 		{
-			name: "Check fee greater than balance",
+			name: "Native payment ignores gas-budget-default",
 			asset: xc.NewChainConfig(xc.XLM).
 				WithGasBudgetDefault(xc.NewAmountHumanReadableFromFloat(5.00000)).
 				WithTransactionActiveTime(txActiveTime).
@@ -181,8 +183,11 @@ func TestFetchTxInput(t *testing.T) {
 				TxInputEnvelope: xc.TxInputEnvelope{Type: "xlm"},
 				SequenceOld:     1213,
 				Sequence:        integer.Int64(1213),
-				// Balance*10^7 - Amount
-				MaxFee: 20000000 - 100,
+				// Even when gas_budget_default is much larger, MaxFee is set to
+				// the actual inclusion fee (base_fee * num_ops). The previous
+				// behaviour subtracted the transfer amount and capped against
+				// gas_budget_default, which broke inclusive-fee sweeps.
+				MaxFee: 100,
 				// 2h * nanoseconds (10^9)
 				TransactionActiveTime: time.Duration(7200 * 1e9),
 				MinLedgerSequence:     1111,
@@ -247,14 +252,97 @@ func TestFetchTxInput(t *testing.T) {
 				TxInputEnvelope: xc.TxInputEnvelope{Type: "xlm"},
 				SequenceOld:     1213,
 				Sequence:        integer.Int64(1213),
-				// Balance*10^7
-				MaxFee: 20000000,
+				// Token transfer with trustline creation: 2 operations
+				// (ChangeTrust + Payment), so MaxFee = base_fee * num_ops = 100 * 2.
+				// MinBalance is not relevant for token transfers (the native
+				// balance is not the transferred asset).
+				MaxFee: 200,
 				// 2h * nanoseconds (10^9)
 				TransactionActiveTime: time.Duration(7200 * 1e9),
 				MinLedgerSequence:     1111,
 				Passphrase:            "Test SDF Network ; September 2015",
 				DestinationFunded:     true,
-				NeedsCreateTrustline: true,
+				NeedsCreateTrustline:  true,
+			},
+		},
+		{
+			// Full sweep on an account with no subentries -> AccountMerge.
+			name: "Sweep with account-merge",
+			asset: xc.NewChainConfig(xc.XLM).
+				WithGasBudgetDefault(xc.NewAmountHumanReadableFromFloat(1.00000)).
+				WithTransactionActiveTime(txActiveTime).
+				WithChainID("Test SDF Network ; September 2015"),
+			// Balance is 2 XLM, sweep the entire amount.
+			amount: xc.NewAmountBlockchainFromUint64(20_000_000),
+			getAccountResult: types.GetAccountResult{
+				Sequence:      "1212",
+				SubentryCount: 0,
+				Balances: []types.Balance{
+					{Balance: "2.0", AssetType: "native"},
+				},
+			},
+			getLatestLedgerResult: types.GetLatestLedgerResult{
+				Embedded: types.Records{
+					Records: []types.GetLedgerResult{
+						{Id: "5", Hash: "h", Sequence: 1111},
+					},
+				},
+			},
+			err: "",
+			expectedTxInput: txinput.TxInput{
+				TxInputEnvelope: xc.TxInputEnvelope{Type: "xlm"},
+				SequenceOld:     1213,
+				Sequence:        integer.Int64(1213),
+				// MaxFee = base_fee * num_ops = 100 * 1 (the AccountMerge op).
+				MaxFee: 100,
+				// AccountMerge releases the reserve, so we do not need to
+				// surface MinBalance — GetFeeLimit only reads it under
+				// MustReserve.
+				AccountMerge:          true,
+				TransactionActiveTime: time.Duration(7200 * 1e9),
+				MinLedgerSequence:     1111,
+				Passphrase:            "Test SDF Network ; September 2015",
+				DestinationFunded:     true,
+			},
+		},
+		{
+			// Full sweep on an account that holds at least one subentry (e.g.
+			// a trustline) -> AccountMerge is forbidden, so the reserve must
+			// remain in the source.
+			name: "Sweep with reserve (subentry blocks merge)",
+			asset: xc.NewChainConfig(xc.XLM).
+				WithGasBudgetDefault(xc.NewAmountHumanReadableFromFloat(1.00000)).
+				WithTransactionActiveTime(txActiveTime).
+				WithChainID("Test SDF Network ; September 2015"),
+			amount: xc.NewAmountBlockchainFromUint64(20_000_000),
+			getAccountResult: types.GetAccountResult{
+				Sequence:      "1212",
+				SubentryCount: 1,
+				Balances: []types.Balance{
+					{Balance: "2.0", AssetType: "native"},
+				},
+			},
+			getLatestLedgerResult: types.GetLatestLedgerResult{
+				Embedded: types.Records{
+					Records: []types.GetLedgerResult{
+						{Id: "5", Hash: "h", Sequence: 1111},
+					},
+				},
+			},
+			err: "",
+			expectedTxInput: txinput.TxInput{
+				TxInputEnvelope: xc.TxInputEnvelope{Type: "xlm"},
+				SequenceOld:     1213,
+				Sequence:        integer.Int64(1213),
+				// MaxFee = base_fee * num_ops = 100 * 1.
+				MaxFee: 100,
+				// (2 + 1) * 5_000_000 = 15_000_000 stroops (1.5 XLM).
+				MinBalance:            xc.NewAmountBlockchainFromUint64(15_000_000),
+				MustReserve:           true,
+				TransactionActiveTime: time.Duration(7200 * 1e9),
+				MinLedgerSequence:     1111,
+				Passphrase:            "Test SDF Network ; September 2015",
+				DestinationFunded:     true,
 			},
 		},
 	}

--- a/chain/xlm/client/types/rpc.go
+++ b/chain/xlm/client/types/rpc.go
@@ -64,6 +64,13 @@ type GetLedgerResult struct {
 	Hash     string `json:"hash"`
 	Sequence int64  `json:"sequence"`
 	ClosedAt string `json:"closed_at"`
+	// BaseFeeInStroops is the network's per-operation inclusion fee at this ledger
+	// (typically 100). Used to compute the actual fee a Payment will be charged.
+	BaseFeeInStroops int64 `json:"base_fee_in_stroops,omitempty"`
+	// BaseReserveInStroops is the per-subentry reserve at this ledger (typically
+	// 5_000_000 = 0.5 XLM). The minimum balance an account must hold is
+	// (2 + subentry_count) * BaseReserveInStroops.
+	BaseReserveInStroops int64 `json:"base_reserve_in_stroops,omitempty"`
 }
 
 type Balance struct {
@@ -76,8 +83,12 @@ type Balance struct {
 }
 
 type GetAccountResult struct {
-	Sequence string    `json:"sequence"`
-	Balances []Balance `json:"balances"`
+	Sequence string `json:"sequence"`
+	// SubentryCount counts the trustlines, signers, offers, data entries and
+	// sponsorships owned by the account. AccountMerge requires this to be 0;
+	// the account's minimum balance is (2 + SubentryCount) * base_reserve.
+	SubentryCount int       `json:"subentry_count"`
+	Balances      []Balance `json:"balances"`
 }
 
 func (account *GetAccountResult) GetNativeBalance() (xc.AmountBlockchain, error) {

--- a/chain/xlm/tx_input/tx_input.go
+++ b/chain/xlm/tx_input/tx_input.go
@@ -39,9 +39,25 @@ type TxInput struct {
 	SequenceOld int64 `json:"Sequence"`
 	// Sequence uses integer.Int64 to survive JSON roundtrip without float64 precision loss.
 	Sequence integer.Int64 `json:"sequence"`
-	// Stellar requires the MaxFee specification, which defines the maximum amount
-	// we are willing to spend on the transaction fee.
+	// MaxFee is the per-tx inclusion fee written into the tx envelope. We
+	// populate it with the actual fee the network is expected to charge
+	// (base_fee_in_stroops * num_operations from the latest ledger), so that
+	// the on-chain charge and the inclusive-fee deduction line up.
+	// ChainGasMultiplier can be used to add headroom for fee surges.
 	MaxFee uint32
+	// MinBalance is the minimum balance the source account must hold, derived
+	// from (2 + subentry_count) * base_reserve. Used to drive the sweep logic.
+	MinBalance xc.AmountBlockchain `json:"min_balance,omitempty"`
+	// AccountMerge is set when the user is sweeping their full balance and the
+	// account is eligible to be merged into the destination (subentry_count == 0
+	// and destination is funded). The builder will then emit an AccountMerge
+	// operation instead of Payment so the network reserve is released too.
+	AccountMerge bool `json:"account_merge,omitempty"`
+	// MustReserve is set when the user is sweeping but the account is not
+	// eligible for AccountMerge. The minimum balance must remain in the source
+	// account, so inclusive-fee spending deducts it in addition to the network
+	// fee (see GetFeeLimit).
+	MustReserve bool `json:"must_reserve,omitempty"`
 	// Specifies the duration for which a transaction remains valid after being submitted.
 	TransactionActiveTime time.Duration
 	MinLedgerSequence     int64
@@ -144,6 +160,9 @@ func (input *TxInput) SetGasFeePriority(priority xc.GasFeePriority) error {
 
 func (input *TxInput) GetFeeLimit() (xc.AmountBlockchain, xc.ContractAddress) {
 	totalFee := uint64(input.MaxFee) + uint64(input.SorobanResourceFee)
+	if input.MustReserve {
+		totalFee += input.MinBalance.Uint64()
+	}
 	return xc.NewAmountBlockchainFromUint64(totalFee), ""
 }
 


### PR DESCRIPTION
## Summary

Three interlocking bugs prevented `--inclusive-fee` transfers from working correctly on Stellar:

1. **Massive fee over-deduction**: `GetFeeLimit` returned `MaxFee`, which is the user-side ceiling (10_000_000 stroops = 1 XLM on testnet by default) rather than the network's actual fee (`base_fee_in_stroops × num_operations`, typically 100 stroops). A 1 XLM transfer with `--inclusive-fee` had its amount reduced to 0 and the builder rejected it with `xlm transfer produced no operations`.

2. **`MaxFee` collapses to 0 on sweep**: `FetchTransferInput` subtracted the transfer amount from the balance before computing MaxFee. For a full-balance sweep this made MaxFee == 0, so submission failed with `tx_insufficient_fee`.

3. **No reserve / no AccountMerge**: Even with the fee deduction correct, Stellar requires `(2 + subentry_count) × base_reserve` to remain in the account. Sweeps would fail with `tx_insufficient_balance` because nothing released the reserve and the inclusive-fee logic did not account for it.

## Fix

- Add `BaseFee` and `NumOperations` to `TxInput`, populated from `base_fee_in_stroops` on the latest ledger and a helper that mirrors the operation branches in the builder. `GetFeeLimit` prefers these over `MaxFee` so the inclusive-fee deduction matches what the network actually charges. `MaxFee` keeps its role as the user-side ceiling.
- Stop subtracting the transfer amount from the fee-account balance before computing `MaxFee`. `MaxFee` now comes from `gas_budget_default` (still capped at balance for tiny accounts).
- Add `SubentryCount` and `base_reserve_in_stroops` to the Horizon response types so `MinBalance = (2 + subentries) × base_reserve` can be derived.
- Add `AccountMerge` and `MustReserve` flags. On a full-balance sweep:
  - If the destination is funded and the source has no subentries, the builder emits an `AccountMerge` operation (guarded by `InclusiveFeeSpendingEnabled`) so the reserve is released and the entire balance flows to the destination.
  - Otherwise the reserve must stay in the source. `GetFeeLimit` returns `BaseFee*NumOperations + MinBalance` so inclusive-fee deducts both the fee and the reserve, leaving the source with exactly its required minimum.

## Reproduction (before the fix)

Partial inclusive-fee transfer of 1 XLM:
```
$ xc transfer <dest> 1 --chain XLM --inclusive-fee --rpc <testnet>
deducting fee from amount: fee=1 new_amount=0 original_amount=1
Error: could not build transfer: xlm transfer produced no operations: amount must be greater than 0 unless creating a trustline
```

Full-balance sweep:
```
$ xc transfer <dest> 10000.0 --chain XLM --inclusive-fee --rpc <testnet>
deducting fee from amount: fee=0 new_amount=10000 original_amount=10000
Error: failed to submit transaction: TsStatus: ERROR, Hash: <hash>
```

## Test plan

- [x] `go test ./chain/xlm/...` — added two new client test cases (`Sweep with account-merge` and `Sweep with reserve (subentry blocks merge)`), a builder test for the AccountMerge path, and updated the three existing tests to include the new fields.
- [x] Full suite: `go test -tags not_ci ./...` passes.
- [x] Manual end-to-end on Stellar testnet:
  - **Partial inclusive-fee (1 XLM)**: succeeds; recipient gets 0.99999 XLM, fee charged is 100 stroops.
  - **Sweep with AccountMerge** (account has no subentries): succeeds; source is deleted, destination receives `balance - 100` stroops.
  - **Sweep with `MustReserve`** (account has a USDC trustline → 1 subentry): succeeds; source is left with exactly 15_000_000 stroops = 1.5 XLM = `(2+1) × 0.5 XLM`.