### PR TITLE
cosmos: replace error-message gas estimator; fix HASH (Provenance flatfees)

### DIFF
--- a/chain/cosmos/builder/builder.go
+++ b/chain/cosmos/builder/builder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	stdmath "math"
 	"math/big"
 	"sort"
 
@@ -145,10 +146,13 @@ func (txBuilder TxBuilder) calculateFees(amount xc.AmountBlockchain, contractMay
 	if gasDenom == "" {
 		gasDenom = asset.ChainCoin
 	}
+	// Use Ceil so fractional gas prices (e.g. Celestia's 0.004 utia/gas)
+	// don't truncate the fee one stroop short of the validator's required
+	// minimum.
 	feeCoins := types.Coins{
 		{
 			Denom:  gasDenom,
-			Amount: math.NewIntFromUint64(uint64(input.GasPrice * float64(input.GasLimit))),
+			Amount: math.NewIntFromUint64(uint64(stdmath.Ceil(input.GasPrice * float64(input.GasLimit)))),
 		},
 	}
 	if includeTax {

--- a/chain/cosmos/client/client.go
+++ b/chain/cosmos/client/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 
 	comettypes "github.com/cometbft/cometbft/rpc/core/types"
@@ -153,12 +154,114 @@ func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.Tra
 		logrus.WithFields(logrus.Fields{
 			"gas_limit_multiplier": gasLimitMultiplier,
 			"gas_used":             res.GasInfo.GasUsed,
+			"gas_wanted":           res.GasInfo.GasWanted,
 			"from":                 args.GetFrom(),
 			"contract":             contract,
 		}).Debug("simulated tx")
 	}
 
+	// Clamp GasLimit and rescale GasPrice so total fee (Amount = GasPrice *
+	// GasLimit) stays constant. Provenance with x/flatfees illustrates why
+	// this is needed: its simulator returns gas_used = msg_fee_in_nhash, a
+	// number that can far exceed the chain's per-tx ceiling (= block max_gas)
+	// when used as the literal GasLimit. On standard cosmos chains the clamp
+	// is a no-op because sim.GasUsed is real execution gas, well under the
+	// ceiling.
+	if err := client.clampGasLimit(ctx, baseTxInput); err != nil {
+		// A failure here just means we couldn't query the chain ceiling; the
+		// tx may still succeed if GasLimit happens to be small enough.
+		logrus.WithError(err).WithField("chain", client.Asset.GetChain().Chain).Debug("could not query block max_gas; submitting un-clamped")
+	}
+
 	return baseTxInput, nil
+}
+
+// clampGasLimit caps txInput.GasLimit at the chain's per-tx ceiling (block
+// max_gas, queried via consensus params) while keeping the total fee constant
+// by scaling GasPrice up. The final GasLimit is also bounded below by what's
+// required to keep the resulting virtual GasPrice >= the mempool floor (so
+// validators accept the tx).
+//
+// Normal cosmos txs use well under a million gas; we only bother querying
+// consensus params when the simulated GasLimit is large enough that the
+// chain ceiling might actually bind. The pathological case is Provenance
+// flatfees, where the simulator can return billions of "gas" as a way of
+// encoding the msg fee.
+const gasLimitClampThreshold = 5_000_000
+
+func (client *Client) clampGasLimit(ctx context.Context, input *tx_input.TxInput) error {
+	if input.GasLimit <= gasLimitClampThreshold || input.GasPrice <= 0 {
+		return nil
+	}
+	maxGas, err := client.queryBlockMaxGas(ctx)
+	if err != nil {
+		return err
+	}
+	// Leave some headroom under block.max_gas so the tx can still share a
+	// block with anything else.
+	const headroomDivisor = 2
+	var safeMax uint64
+	if maxGas > 0 {
+		safeMax = maxGas / headroomDivisor
+	}
+	if safeMax == 0 || input.GasLimit <= safeMax {
+		// Nothing to clamp.
+		return nil
+	}
+
+	// Query the validator's local mempool floor. The configured GasPrice may
+	// be below this floor (e.g. on Provenance flatfees we set it to 1 so the
+	// simulator returns the correct fee in gas_used, but the real mempool
+	// floor is much higher). After clamping, the resulting virtual GasPrice
+	// must still clear that floor.
+	denoms := feeDenoms(client.Asset.GetChain())
+	mempoolFloor := input.GasPrice
+	if floor, err := client.queryNodeMinGasPrice(ctx, denoms); err == nil && !floor.Amount.IsNil() && !floor.Amount.IsZero() {
+		if f, _ := floor.Amount.Float64(); f > mempoolFloor {
+			mempoolFloor = f
+		}
+	}
+	// Add a small headroom over the floor so a tiny upward fluctuation
+	// between simulate and broadcast doesn't get our tx rejected.
+	mempoolFloor *= 1.10
+
+	totalFee := float64(input.GasLimit) * input.GasPrice
+	newLimit := safeMax
+	if newLimit > uint64(math.Floor(totalFee/mempoolFloor)) {
+		newLimit = uint64(math.Floor(totalFee / mempoolFloor))
+	}
+	if newLimit >= input.GasLimit {
+		return nil
+	}
+
+	prevLimit := input.GasLimit
+	prevPrice := input.GasPrice
+	input.GasLimit = newLimit
+	input.GasPrice = totalFee / float64(newLimit)
+
+	logrus.WithFields(logrus.Fields{
+		"chain":          client.Asset.GetChain().Chain,
+		"block_max_gas":  maxGas,
+		"mempool_floor":  mempoolFloor,
+		"previous_limit": prevLimit,
+		"previous_price": prevPrice,
+		"new_limit":      input.GasLimit,
+		"new_price":      input.GasPrice,
+		"total_fee":      totalFee,
+	}).Debug("clamped gas_limit and rescaled gas_price")
+
+	return nil
+}
+
+func feeDenoms(cfg *xc.ChainConfig) []string {
+	denoms := []string{}
+	if cfg.GasCoin != "" {
+		denoms = append(denoms, cfg.GasCoin)
+	}
+	if cfg.ChainCoin != "" && cfg.ChainCoin != cfg.GasCoin {
+		denoms = append(denoms, cfg.ChainCoin)
+	}
+	return denoms
 }
 
 type txBuilder func(input xc.TxInput) (xc.Tx, error)

--- a/chain/cosmos/client/client_test.go
+++ b/chain/cosmos/client/client_test.go
@@ -31,6 +31,18 @@ func TestNewClient(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// makeNodeConfigUnsupportedResponse returns an abci_query response that looks
+// like the node does not support the cosmos.base.node.v1beta1.Service/Config
+// endpoint. The Cosmos client uses this as its primary source for the
+// minimum gas price; an "unimplemented" reply makes it fall through to the
+// legacy free-tx hack which the rest of these test responses exercise.
+func makeNodeConfigUnsupportedResponse(id int) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":%d,"result":{"response":{"code":12,"log":"unknown query path","codespace":"sdk"}}}`,
+		id,
+	)
+}
+
 func makeSimulateResponse(gasUsed uint64, gasRequested uint64) string {
 	response := cosmostx.SimulateResponse{
 		GasInfo: &types.GasInfo{
@@ -78,11 +90,14 @@ func TestFetchTxInput(t *testing.T) {
 			resp: []string{
 				`{"jsonrpc":"2.0","id":0,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"CqABCiAvY29zbW9zLmF1dGgudjFiZXRhMS5CYXNlQWNjb3VudBJ8Cix0ZXJyYTFkcDNxMzA1aGd0dHQ4bjM0cnQ4cmc5eHBhbmM0Mno0eWU3dXBmZxJGCh8vY29zbW9zLmNyeXB0by5zZWNwMjU2azEuUHViS2V5EiMKIQL89yTJff+sICHvoYGML+87y7dTyiKROo21557Eo97g0RjZhgEgAw==","proofOps":null,"height":"2803726","codespace":""}}}`,
 				`{"jsonrpc": "2.0","id": 1,"result": {"node_info": {"protocol_version": {},"network": "chainId"},"sync_info": {"latest_block_height": "123"},"validator_info": {}}}`,
-				`{"jsonrpc":"2.0","id":2,"result":{"code":13,"data":"","log":"insufficient fees; got: 0uluna required: 15000uluna: insufficient fee","codespace":"sdk","hash":"C96E183E5FE6288EFA254C8003F5DD37D3EA51889E09F45CAA0749EF6FE25420"}}`,
+				// node Config endpoint (new primary source); pretend it's not
+				// supported so the legacy free-tx hack below is exercised.
+				makeNodeConfigUnsupportedResponse(2),
+				`{"jsonrpc":"2.0","id":3,"result":{"code":13,"data":"","log":"insufficient fees; got: 0uluna required: 15000uluna: insufficient fee","codespace":"sdk","hash":"C96E183E5FE6288EFA254C8003F5DD37D3EA51889E09F45CAA0749EF6FE25420"}}`,
 				// get x/bank balance
-				`{"jsonrpc":"2.0","id":3,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"ChAKBXVsdW5hEgc0OTc5MDYz","proofOps":null,"height":"12817698","codespace":""}}}`,
+				`{"jsonrpc":"2.0","id":4,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"ChAKBXVsdW5hEgc0OTc5MDYz","proofOps":null,"height":"12817698","codespace":""}}}`,
 				// get tx simulate
-				fmt.Sprintf(`{"jsonrpc":"2.0","id":4,"result":%s}`, makeSimulateResponse(50_000, 100_000)),
+				fmt.Sprintf(`{"jsonrpc":"2.0","id":5,"result":%s}`, makeSimulateResponse(50_000, 100_000)),
 			},
 			txInput: &tx_input.TxInput{
 				TxInputEnvelope: xc.TxInputEnvelope{Type: "cosmos"},
@@ -104,11 +119,12 @@ func TestFetchTxInput(t *testing.T) {
 			resp: []string{
 				`{"jsonrpc":"2.0","id":0,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"CqgBCiAvY29zbW9zLmF1dGgudjFiZXRhMS5CYXNlQWNjb3VudBKDAQoreHBsYTFoZHZmNnZ2NWFtYzd3cDg0anMwbHMyN2FwZWt3eHByMGdlOTZrZxJPCigvZXRoZXJtaW50LmNyeXB0by52MS5ldGhzZWNwMjU2azEuUHViS2V5EiMKIQK3jbFRLCBKbDkZ7HGZcc6O14WuCUStGu7+qycD0eVNAhiiCyAE","proofOps":null,"height":"1359950","codespace":""}}}`,
 				`{"jsonrpc": "2.0","id": 1,"result": {"node_info": {"protocol_version": {},"network": "chainId"},"sync_info": {},"validator_info": {}}}`,
-				`{"jsonrpc":"2.0","id":2,"result":{"code":13,"data":"","log":"insufficient fees; got: 0axpla required: 850000000000axpla: insufficient fee","codespace":"sdk","hash":"C96E183E5FE6288EFA254C8003F5DD37D3EA51889E09F45CAA0749EF6FE25420"}}`,
+				makeNodeConfigUnsupportedResponse(2),
+				`{"jsonrpc":"2.0","id":3,"result":{"code":13,"data":"","log":"insufficient fees; got: 0axpla required: 850000000000axpla: insufficient fee","codespace":"sdk","hash":"C96E183E5FE6288EFA254C8003F5DD37D3EA51889E09F45CAA0749EF6FE25420"}}`,
 				// get x/bank balance
-				`{"jsonrpc":"2.0","id":3,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"ChAKBXVsdW5hEgc0OTc5MDYz","proofOps":null,"height":"12817698","codespace":""}}}`,
+				`{"jsonrpc":"2.0","id":4,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"ChAKBXVsdW5hEgc0OTc5MDYz","proofOps":null,"height":"12817698","codespace":""}}}`,
 				// get tx simulate
-				fmt.Sprintf(`{"jsonrpc":"2.0","id":4,"result":%s}`, makeSimulateResponse(50_000, 100_000)),
+				fmt.Sprintf(`{"jsonrpc":"2.0","id":5,"result":%s}`, makeSimulateResponse(50_000, 100_000)),
 			},
 			txInput: &tx_input.TxInput{
 				TxInputEnvelope: xc.TxInputEnvelope{Type: "cosmos"},
@@ -133,14 +149,16 @@ func TestFetchTxInput(t *testing.T) {
 				`{"jsonrpc":"2.0","id":0,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"CqgBCiAvY29zbW9zLmF1dGgudjFiZXRhMS5CYXNlQWNjb3VudBKDAQoreHBsYTFoZHZmNnZ2NWFtYzd3cDg0anMwbHMyN2FwZWt3eHByMGdlOTZrZxJPCigvZXRoZXJtaW50LmNyeXB0by52MS5ldGhzZWNwMjU2azEuUHViS2V5EiMKIQK3jbFRLCBKbDkZ7HGZcc6O14WuCUStGu7+qycD0eVNAhiiCyAE","proofOps":null,"height":"1359950","codespace":""}}}`,
 				// chain status
 				`{"jsonrpc": "2.0","id": 1,"result": {"node_info": {"protocol_version": {},"network": "chainId"},"sync_info": {},"validator_info": {}}}`,
-				// fee estimation
-				`{"jsonrpc":"2.0","id":2,"result":{"code":13,"data":"","log":"insufficient fees; got: 0axpla required: 850000000000axpla: insufficient fee","codespace":"sdk","hash":"C96E183E5FE6288EFA254C8003F5DD37D3EA51889E09F45CAA0749EF6FE25420"}}`,
+				// node Config (unsupported -> fall through to legacy hack)
+				makeNodeConfigUnsupportedResponse(2),
+				// fee estimation (legacy free-tx hack)
+				`{"jsonrpc":"2.0","id":3,"result":{"code":13,"data":"","log":"insufficient fees; got: 0axpla required: 850000000000axpla: insufficient fee","codespace":"sdk","hash":"C96E183E5FE6288EFA254C8003F5DD37D3EA51889E09F45CAA0749EF6FE25420"}}`,
 				// get x/bank balance (fail)
-				`{"jsonrpc":"2.0","id":3,"result":{"response":{"code":1,"log":"","info":"bad denom","index":"0","key":null,"value":"","proofOps":null,"height":"12817698","codespace":""}}}`,
+				`{"jsonrpc":"2.0","id":4,"result":{"response":{"code":1,"log":"","info":"bad denom","index":"0","key":null,"value":"","proofOps":null,"height":"12817698","codespace":""}}}`,
 				// get x/wasm cw20 balance
-				`{"jsonrpc":"2.0","id":4,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"ChZ7ImJhbGFuY2UiOiI0Mzk4NDEyNyJ9","proofOps":null,"height":"12817698","codespace":""}}}`,
+				`{"jsonrpc":"2.0","id":5,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"ChZ7ImJhbGFuY2UiOiI0Mzk4NDEyNyJ9","proofOps":null,"height":"12817698","codespace":""}}}`,
 				// get tx simulate
-				fmt.Sprintf(`{"jsonrpc":"2.0","id":5,"result":%s}`, makeSimulateResponse(50_000, 100_000)),
+				fmt.Sprintf(`{"jsonrpc":"2.0","id":6,"result":%s}`, makeSimulateResponse(50_000, 100_000)),
 			},
 			txInput: &tx_input.TxInput{
 				TxInputEnvelope: xc.TxInputEnvelope{Type: "cosmos"},
@@ -168,12 +186,14 @@ func TestFetchTxInput(t *testing.T) {
 				`{"jsonrpc":"2.0","id":1,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"CqgBCiAvY29zbW9zLmF1dGgudjFiZXRhMS5CYXNlQWNjb3VudBKDAQoreHBsYTFoZHZmNnZ2NWFtYzd3cDg0anMwbHMyN2FwZWt3eHByMGdlOTZrZxJPCigvZXRoZXJtaW50LmNyeXB0by52MS5ldGhzZWNwMjU2azEuUHViS2V5EiMKIQK3jbFRLCBKbDkZ7HGZcc6O14WuCUStGu7+qycD0eVNAhiiCyAE","proofOps":null,"height":"1359950","codespace":""}}}`,
 				// chain status
 				`{"jsonrpc": "2.0","id": 2,"result": {"node_info": {"protocol_version": {},"network": "chainId"},"sync_info": {},"validator_info": {}}}`,
-				// fee estimation
-				`{"jsonrpc":"2.0","id":3,"result":{"code":13,"data":"","log":"insufficient fees; got: 0axpla required: 850000000000axpla: insufficient fee","codespace":"sdk","hash":"C96E183E5FE6288EFA254C8003F5DD37D3EA51889E09F45CAA0749EF6FE25420"}}`,
+				// node Config (unsupported -> fall through to legacy hack)
+				makeNodeConfigUnsupportedResponse(3),
+				// fee estimation (legacy free-tx hack)
+				`{"jsonrpc":"2.0","id":4,"result":{"code":13,"data":"","log":"insufficient fees; got: 0axpla required: 850000000000axpla: insufficient fee","codespace":"sdk","hash":"C96E183E5FE6288EFA254C8003F5DD37D3EA51889E09F45CAA0749EF6FE25420"}}`,
 				// get x/bank balance
-				`{"jsonrpc":"2.0","id":4,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"ChAKBXVsdW5hEgc0OTc5MDYz","proofOps":null,"height":"12817698","codespace":""}}}`,
+				`{"jsonrpc":"2.0","id":5,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"ChAKBXVsdW5hEgc0OTc5MDYz","proofOps":null,"height":"12817698","codespace":""}}}`,
 				// get tx simulate
-				fmt.Sprintf(`{"jsonrpc":"2.0","id":5,"result":%s}`, makeSimulateResponse(50_000, 100_000)),
+				fmt.Sprintf(`{"jsonrpc":"2.0","id":6,"result":%s}`, makeSimulateResponse(50_000, 100_000)),
 			},
 			txInput: &tx_input.TxInput{
 				TxInputEnvelope:       xc.TxInputEnvelope{Type: "cosmos"},
@@ -197,12 +217,13 @@ func TestFetchTxInput(t *testing.T) {
 			resp: []string{
 				`{"jsonrpc":"2.0","id":0,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"CqABCiAvY29zbW9zLmF1dGgudjFiZXRhMS5CYXNlQWNjb3VudBJ8Cix0ZXJyYTFkcDNxMzA1aGd0dHQ4bjM0cnQ4cmc5eHBhbmM0Mno0eWU3dXBmZxJGCh8vY29zbW9zLmNyeXB0by5zZWNwMjU2azEuUHViS2V5EiMKIQL89yTJff+sICHvoYGML+87y7dTyiKROo21557Eo97g0RjZhgEgAw==","proofOps":null,"height":"2803726","codespace":""}}}`,
 				`{"jsonrpc": "2.0","id": 1,"result": {"node_info": {"protocol_version": {},"network": "chainId"},"sync_info": {"latest_block_height": "123"},"validator_info": {}}}`,
-				`{"jsonrpc":"2.0","id":2,"result":{"code":13,"data":"","log":"insufficient fees; got: 0uluna required: 15000uluna: insufficient fee","codespace":"sdk","hash":"C96E183E5FE6288EFA254C8003F5DD37D3EA51889E09F45CAA0749EF6FE25420"}}`,
+				makeNodeConfigUnsupportedResponse(2),
+				`{"jsonrpc":"2.0","id":3,"result":{"code":13,"data":"","log":"insufficient fees; got: 0uluna required: 15000uluna: insufficient fee","codespace":"sdk","hash":"C96E183E5FE6288EFA254C8003F5DD37D3EA51889E09F45CAA0749EF6FE25420"}}`,
 				// get x/bank balance
-				`{"jsonrpc":"2.0","id":3,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"ChAKBXVsdW5hEgc0OTc5MDYz","proofOps":null,"height":"12817698","codespace":""}}}`,
+				`{"jsonrpc":"2.0","id":4,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":null,"value":"ChAKBXVsdW5hEgc0OTc5MDYz","proofOps":null,"height":"12817698","codespace":""}}}`,
 				// get tx simulate
-				`{"jsonrpc":"2.0","id":4,"error":{"message": "account sequence mismatch: ...", "code": 123}}`,
-				`{"jsonrpc":"2.0","id":4,"error":{"message": "account sequence mismatch: ...", "code": 123}}`,
+				`{"jsonrpc":"2.0","id":5,"error":{"message": "account sequence mismatch: ...", "code": 123}}`,
+				`{"jsonrpc":"2.0","id":5,"error":{"message": "account sequence mismatch: ...", "code": 123}}`,
 			},
 			txInput: &tx_input.TxInput{
 				TxInputEnvelope: xc.TxInputEnvelope{Type: "cosmos"},

--- a/chain/cosmos/client/gas.go
+++ b/chain/cosmos/client/gas.go
@@ -12,6 +12,8 @@ import (
 	"github.com/cordialsys/crosschain/chain/cosmos/tx"
 	"github.com/cordialsys/crosschain/chain/cosmos/tx_input"
 	"github.com/cordialsys/crosschain/chain/cosmos/tx_input/gas"
+	rpcclient "github.com/cometbft/cometbft/rpc/client"
+	"github.com/cosmos/cosmos-sdk/client/grpc/node"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -19,71 +21,140 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// EstimateGas estimates gas price for a Cosmos chain
-func (client *Client) EstimateGasPrice(ctx context.Context) (float64, error) {
-	zero := float64(0)
-	native := client.Asset.GetChain()
-	denoms := []string{}
-	if native.GasCoin != "" {
-		denoms = append(denoms, native.GasCoin)
+// queryNodeMinGasPrice returns the validator's local minimum_gas_prices via
+// the cosmos.base.node.v1beta1.Service/Config gRPC endpoint. The response is
+// a coin string like "1905nhash" or "0.005uatom"; we return the matching coin
+// for one of the chain's known fee denoms, or an empty Coin when the node
+// returned no value (some operators leave it unset).
+func (client *Client) queryNodeMinGasPrice(ctx context.Context, denoms []string) (sdk.DecCoin, error) {
+	nodeClient := node.NewServiceClient(client.Ctx)
+	resp, err := nodeClient.Config(ctx, &node.ConfigRequest{})
+	if err != nil {
+		return sdk.DecCoin{}, fmt.Errorf("node Config query failed: %w", err)
 	}
-	if native.ChainCoin != "" && native.ChainCoin != native.GasCoin {
-		denoms = append(denoms, native.ChainCoin)
+	raw := resp.MinimumGasPrice
+	if raw == "" {
+		return sdk.DecCoin{}, nil
+	}
+	// MinimumGasPrices is a comma-separated list of "<dec><denom>" pairs.
+	prices, err := sdk.ParseDecCoins(raw)
+	if err != nil {
+		return sdk.DecCoin{}, fmt.Errorf("could not parse minimum_gas_price %q: %w", raw, err)
+	}
+	for _, want := range denoms {
+		for _, price := range prices {
+			if price.Denom == want {
+				return price, nil
+			}
+		}
+	}
+	// No matching denom; return the first entry so the caller can decide
+	// whether to use it (mismatched denoms are rare in practice).
+	if len(prices) > 0 {
+		return prices[0], nil
+	}
+	return sdk.DecCoin{}, nil
+}
+
+// queryBlockMaxGas returns the per-block gas ceiling, which is also the per-tx
+// hard ceiling enforced by the chain. Returns 0 when the chain reports no cap
+// (block.max_gas == -1, i.e. unlimited) or when the underlying RPC client
+// does not expose ConsensusParams.
+func (client *Client) queryBlockMaxGas(ctx context.Context) (uint64, error) {
+	network, ok := client.Ctx.Client.(rpcclient.NetworkClient)
+	if !ok {
+		return 0, nil
+	}
+	res, err := network.ConsensusParams(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("consensus params query failed: %w", err)
+	}
+	if res == nil || res.ConsensusParams.Block.MaxGas <= 0 {
+		return 0, nil
+	}
+	return uint64(res.ConsensusParams.Block.MaxGas), nil
+}
+
+// EstimateGasPrice returns the per-gas fee (in the gas/native denom's base
+// units) the local mempool will require. Sources are tried in order:
+//
+//  1. Chain config `ChainMinGasPrice` (operator override, human-decimal units).
+//     Treated as authoritative when set: operators may pick a value below
+//     the validator's local floor on purpose, e.g. Provenance flatfees uses
+//     gas_price=1nhash so the simulator's gas_used acts as the fee in nhash.
+//  2. cosmos.base.node.v1beta1.Service/Config gRPC query against the RPC
+//     node (the validator's own minimum_gas_prices, SDK >= 0.47).
+//  3. Legacy free-tx hack: broadcast a 0-fee tx and parse the rejection
+//     error. This is the only source that reflects app-level minimums (e.g.
+//     Celestia x/minfee at 0.004 utia/gas) when the node operator hasn't
+//     set local minimum_gas_prices.
+//  4. `GasBudgetDefault` as a last resort.
+//
+// Operators are responsible for keeping ChainMinGasPrice in sync with the
+// chains they operate against; an obviously-stale value will surface as a
+// fee-rejection on broadcast.
+func (client *Client) EstimateGasPrice(ctx context.Context) (float64, error) {
+	native := client.Asset.GetChain()
+	denoms := feeDenoms(native)
+
+	// 1. Operator override.
+	if native.ChainMinGasPrice > 0 {
+		factor := math.Pow10(int(native.Decimals)) * 1.01
+		return native.ChainMinGasPrice * factor, nil
 	}
 
-	gasLimitForEstimate := uint64(1_000_000)
+	// 2. Node Config gRPC query.
+	if price, err := client.queryNodeMinGasPrice(ctx, denoms); err == nil && !price.Amount.IsNil() && !price.Amount.IsZero() {
+		perGas, _ := price.Amount.MulInt64(101).QuoInt64(100).Float64()
+		return perGas, nil
+	} else if err != nil {
+		logrus.WithError(err).WithField("chain", native.Chain).Debug("node Config query failed")
+	}
+
+	// 3. Legacy free-tx hack.
+	if legacy, err := client.estimateGasPriceFromErrorMessage(denoms); err == nil && legacy > 0 {
+		return legacy, nil
+	}
+
+	// 4. Last resort.
+	defaultBudgetHuman := native.GasBudgetDefault
+	defaultBudget := defaultBudgetHuman.ToBlockchain(native.Decimals)
+	if defaultBudget.IsZero() {
+		return 0, fmt.Errorf("could not estimate gas price - contact Cordial Systems to update '%s' chain fee configuration", native.Chain)
+	}
+	return gas.TotalFeeToFeePerGas(defaultBudget.String(), 1_000_000), nil
+}
+
+// estimateGasPriceFromErrorMessage is the legacy approach: submit a tx with
+// gas_price=0 and parse the validator's rejection error to recover the
+// minimum gas price. Kept as a fallback for chains where the node Config
+// query returns nothing.
+func (client *Client) estimateGasPriceFromErrorMessage(denoms []string) (float64, error) {
+	const gasLimitForEstimate = uint64(1_000_000)
 	tx, err := client.BuildReferenceTransfer(gasLimitForEstimate)
 	if err != nil {
-		return zero, fmt.Errorf("could not build estimate gas tx: %v", err)
+		return 0, fmt.Errorf("could not build estimate gas tx: %v", err)
 	}
 	txBytes, err := tx.Serialize()
 	if err != nil {
-		return zero, fmt.Errorf("could not serialize tx: %v", err)
+		return 0, fmt.Errorf("could not serialize tx: %v", err)
 	}
 
 	var minFeeRaw sdk.Coin
 	var minFeeErr error
-	// The min fee error may come from the RPC error message, or in the res.RawLog field.
 	res, err := client.Ctx.BroadcastTx(txBytes)
 	if err != nil {
 		minFeeRaw, minFeeErr = gas.ParseMinGasError(err.Error(), denoms)
 		if minFeeErr != nil {
-			return zero, fmt.Errorf("could not broadcast tx: %v", err)
+			return 0, fmt.Errorf("could not broadcast tx: %v", err)
 		}
 	} else {
 		minFeeRaw, minFeeErr = gas.ParseMinGasError(res.RawLog, denoms)
 	}
-
 	if minFeeErr != nil || minFeeRaw.Amount.IsZero() {
-		// This is more common that the hack does not work
-		logrus.WithField("chain", native.Chain).WithField("error", err).Warn("could not parse min gas error")
-
-		// 1. First consider if min gas price is set by the chain config
-		if client.Asset.GetChain().ChainMinGasPrice > 0 {
-			// gas price is in human quantity, need to convert to blockchain quantity
-			factor := math.Pow10(int(client.Asset.GetChain().Decimals))
-			// add additional 1% gas to cover floating point rounding errors
-			factor = factor * 1.01
-			return client.Asset.GetChain().ChainMinGasPrice * factor, nil
-		}
-
-		// 2. If not, use the default budget
-		defaultBudgetHuman := client.Asset.GetChain().GasBudgetDefault
-		defaultBudget := defaultBudgetHuman.ToBlockchain(client.Asset.GetChain().Decimals)
-		if defaultBudget.IsZero() {
-			return 0, fmt.Errorf("could not estimate gas price - contact Cordial Systems to update '%s' chain fee configuration", native.Chain)
-		}
-		return gas.TotalFeeToFeePerGas(defaultBudget.String(), gasLimitForEstimate), nil
+		return 0, fmt.Errorf("error parsing did not yield a min fee")
 	}
-
-	// Need to convert total fee into gas price (cost per gas)
-	perGas := gas.TotalFeeToFeePerGas(
-		minFeeRaw.Amount.String(),
-		// credit 1% gas to prevent off-by-one errors
-		// (gasLimitForEstimate*99)/100,
-		gasLimitForEstimate,
-	)
-	return perGas, nil
+	return gas.TotalFeeToFeePerGas(minFeeRaw.Amount.String(), gasLimitForEstimate), nil
 }
 
 // There is no way to estimate gas on cosmos chains.

--- a/chain/cosmos/tx_input/tx_input.go
+++ b/chain/cosmos/tx_input/tx_input.go
@@ -74,8 +74,10 @@ func (input *TxInput) GetFeeLimit() (xc.AmountBlockchain, xc.ContractAddress) {
 	gasLimitInt.SetUint64(input.GasLimit)
 	gasLimit := decimal.NewFromBigInt(gasLimitInt, 0)
 
-	// gasPrice * gasLimit
-	totalSpend := gasPrice.Mul(gasLimit)
+	// gasPrice * gasLimit, rounded up so fractional gas prices match the
+	// builder's Ceil and the inclusive-fee deduction is sufficient to cover
+	// the on-chain fee.
+	totalSpend := gasPrice.Mul(gasLimit).Ceil()
 	totalSpendInt := xc.AmountBlockchain(*totalSpend.BigInt())
 
 	// TODO: consider alt assets fees in cosmos

--- a/factory/defaults/chains/mainnet.yaml
+++ b/factory/defaults/chains/mainnet.yaml
@@ -841,10 +841,15 @@ chains:
     chain_coin_hd_path: 1
     decimals: 9
     fee_limit: "200.0"
-    chain_gas_multiplier: 10.0
-    # translates to roughly max 50 HASH in gas per tx
+    # Provenance migrated to the x/flatfees module: simulation returns the
+    # required fee in nhash via gas_used (assuming gas_price=1nhash/gas).
+    # Set chain_min_gas_price to 1nhash so Amount = sim.gas_used * 1 = msg_fee
+    # and let the cosmos client clamp the resulting (huge) gas_limit to fit
+    # within block.max_gas (rescaling the virtual gas_price up to compensate).
+    chain_min_gas_price: 1.0e-9
+    chain_gas_multiplier: 1.0
+    chain_gas_limit_multiplier: 1.0
     chain_max_gas_price: 125000.0
-    chain_min_gas_price: 0.000002
     native_assets:
       - asset_id: "HASH"
         contract_id: "nhash"

--- a/factory/defaults/chains/testnet.yaml
+++ b/factory/defaults/chains/testnet.yaml
@@ -787,8 +787,14 @@ chains:
     chain_coin: nhash
     chain_coin_hd_path: 1
     decimals: 9
-    chain_gas_multiplier: 10.0
-    # translates to roughly max 50 HASH in gas per tx
+    # Provenance migrated to the x/flatfees module in v1.28: simulation now
+    # returns the required fee in nhash via gas_used (assuming gas_price=1).
+    # We therefore set chain_min_gas_price to 1nhash (=1e-9 in human units)
+    # and skip both fee multipliers so that fee = sim.gas_used * 1 = msg_fee
+    # exactly.
+    chain_min_gas_price: 1.0e-9
+    chain_gas_multiplier: 1.0
+    chain_gas_limit_multiplier: 1.0
     chain_max_gas_price: 125000.0
     native_assets:
       - asset_id: "HASH"


### PR DESCRIPTION
## Summary

Rewrites the cosmos gas estimator to use chain-queried values instead of the previous flaky hack of broadcasting a 0-fee tx and parsing the rejection error string. As a side effect, this fixes HASH (Provenance), which was completely broken — even a plain `MsgSend` was estimating a fee of **67,333 HASH** and tripping `fee_limit: "200"`.

## What was wrong on HASH

Provenance migrated to its `x/flatfees` module in v1.28. Under flatfees, the simulator no longer returns "real gas used" — it returns `total_msg_fee_in_nhash` (assuming `gas_price = 1 nhash/gas` in the simulated tx envelope). For a default `MsgSend` cost of 150 musd ≈ 2.81 HASH, the simulator returns ~2.78B as `gas_used`. The old code took that number at face value and multiplied by the stale `chain_min_gas_price=2e-6 × chain_gas_multiplier=10` (= 20,200 nhash/gas), producing the 67k-HASH fee.

## What changes

### `EstimateGasPrice` rewrite

Sources tried in order:

1. **Operator override** via chain config `ChainMinGasPrice` (human units).
2. **`cosmos.base.node.v1beta1.Service/Config`** gRPC endpoint — the validator's own `minimum_gas_prices` (SDK ≥ 0.47, widely deployed). Returns e.g. `1905nhash`, `0.005uatom`, `160000000inj`.
3. **Legacy free-tx hack** (kept as fallback for older chains).
4. `GasBudgetDefault` as a last resort.

### Clamp + rescale in `FetchTransferInput`

Post-simulation, the new `clampGasLimit` caps `GasLimit` at `block.max_gas / 2` (queried via `consensus_params`) and rescales the virtual `GasPrice` to keep `Amount` constant. It also refuses to push `GasPrice` below the validator's local mempool floor (with a small headroom).

This is a no-op on standard cosmos chains — `sim.gas_used` is real execution gas, well below the block ceiling. The pathological case it handles is Provenance flatfees, where `gas_used` can reach billions because it's encoding `msg_fee_in_nhash`.

### HASH chain defaults

- Removed: `chain_gas_multiplier: 10.0` (stale, from before flatfees)
- Removed: `chain_min_gas_price: 0.000002` (likewise stale)
- Added: `chain_min_gas_price: 1.0e-9` (forces `Amount = sim.gas_used × 1 nhash/gas = msg_fee`)
- Added: `chain_gas_multiplier: 1.0`, `chain_gas_limit_multiplier: 1.0`

The connector-config override of `chain_min_gas_price: 0.000002` was also removed.

## Reproduction (before the fix)

```
$ xc tx-input <addr> --to <addr> --chain HASH --rpc https://rpc.test.provenance.io
warning: could not parse min gas error (HASH)
{ "gas_limit": 3333333333, "gas_price": 20200, ... }   # = 67_333 HASH

$ xc transfer <addr> 1 --chain HASH --inclusive-fee --rpc https://rpc.test.provenance.io
Error: transaction fee may cost up to 67333.3333266 HASH, which is greater than the current limit of 200
```

## Test plan

- [x] `go test -tags not_ci ./...` passes (cosmos client tests updated to include the new node-Config call in the mocked RPC sequence).
- [x] HASH testnet end-to-end:
  - Plain bank send: `gas_limit=1.34M, gas_price=2095nhash/gas, fee=2.81 HASH` ✓ accepted on chain.
  - Inclusive-fee 10 HASH transfer: deducts 2.81 HASH from amount, recipient receives 7.19 HASH ✓.
  - Inclusive-fee sweep: source drained from 83.4 HASH to 0; recipient received the rest minus the per-tx flatfee ✓.
- [x] Standard cosmos chains: existing client unit tests (Cosmos Hub / Terra / XPLA mocks) continue to pass via the legacy fallback path that they exercise.