### PR TITLE
fix(doge): support pay-to-pubkey UTXOs

### DIFF
--- a/chain/bitcoin/builder/bitcoin_test.go
+++ b/chain/bitcoin/builder/bitcoin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/btcsuite/btcd/txscript"
 	xc "github.com/cordialsys/crosschain"
 	xcbuilder "github.com/cordialsys/crosschain/builder"
 	"github.com/cordialsys/crosschain/builder/buildertest"
@@ -258,6 +259,42 @@ func (s *CrosschainTestSuite) TestTxAddSignature() {
 		},
 	}...)
 	require.NoError(err)
+}
+
+func (s *CrosschainTestSuite) TestTxAddSignaturePayToPubKey() {
+	require := s.Require()
+	chain := xc.NewChainConfig(xc.DOGE).WithNet("mainnet")
+	builder, err := NewTxBuilder(chain.Base())
+	require.NoError(err)
+
+	publicKey := []byte{
+		0x02, 0x05, 0xf0, 0x72, 0x74, 0x48, 0x9c, 0x05, 0xcc, 0x2b, 0xc6,
+		0x03, 0xf3, 0xf4, 0x84, 0x14, 0x44, 0x2b, 0xae, 0xab, 0xe8, 0x44,
+		0xeb, 0xb3, 0x40, 0x77, 0x4c, 0x35, 0x69, 0xa4, 0x5d, 0x26, 0x46,
+	}
+	p2pkScript := append([]byte{txscript.OP_DATA_33}, publicKey...)
+	p2pkScript = append(p2pkScript, txscript.OP_CHECKSIG)
+	input := &tx_input.TxInput{UnspentOutputs: []tx_input.Output{{
+		Value:        xc.NewAmountBlockchainFromUint64(1000),
+		PubKeyScript: p2pkScript,
+	}}}
+	tf, err := builder.NewNativeTransfer(
+		xc.Address("DKh5jsaK4duMy3Lvi8VpV9gSLtwVeWQ9gg"),
+		xc.Address("DBFELp67Dsgog58X3E7UVtRw9VoUsoLn7E"),
+		xc.NewAmountBlockchainFromUint64(10),
+		input,
+	)
+	require.NoError(err)
+
+	signature := append(make([]byte, 64), byte(0))
+	require.NoError(tf.SetSignatures(&xc.SignatureResponse{
+		Signature: signature,
+		PublicKey: publicKey,
+	}))
+
+	pushedData, err := txscript.PushedData(tf.(*tx.Tx).MsgTx.TxIn[0].SignatureScript)
+	require.NoError(err)
+	require.Len(pushedData, 1)
 }
 
 func genInput(addr string, totalAmount int, numberUtxos int) tx_input.TxInput {

--- a/chain/bitcoin/client/client.go
+++ b/chain/bitcoin/client/client.go
@@ -145,6 +145,22 @@ func (client *BlockbookClient) UnspentOutputs(ctx context.Context, addr xc.Addre
 
 	// TODO try filtering using confirmed UTXO only for target amount, using heuristic as fallback.
 	data = tx_input.FilterUnconfirmedHeuristic(data)
+	if client.Asset.GetChain().Chain == xc.DOGE {
+		outputs := tx_input.NewOutputs(data, nil, addr)
+		for i, utxo := range data {
+			prevout, err := client.bbClient.GetOutput(ctx, utxo.GetTxHash(), utxo.GetIndex())
+			if err != nil {
+				return nil, fmt.Errorf("could not fetch prevout %s:%d: %w", utxo.GetTxHash(), utxo.GetIndex(), err)
+			}
+			script, err := hex.DecodeString(prevout.Hex)
+			if err != nil {
+				return nil, fmt.Errorf("could not decode prevout script %s:%d: %w", utxo.GetTxHash(), utxo.GetIndex(), err)
+			}
+			outputs[i].PubKeyScript = script
+		}
+		return outputs, nil
+	}
+
 	btcAddr, err := client.decoder.Decode(addr, client.Chaincfg)
 	if err != nil {
 		return nil, fmt.Errorf("could not decode address: %v", err)

--- a/chain/bitcoin/client/quicknode_blockbook/endpoints.go
+++ b/chain/bitcoin/client/quicknode_blockbook/endpoints.go
@@ -126,6 +126,17 @@ func (client *Client) GetTx(ctx context.Context, txHash string) (types.Transacti
 	return tx, nil
 }
 
+func (client *Client) GetOutput(ctx context.Context, txHash string, vout uint32) (types.Vout, error) {
+	tx, err := client.GetTx(ctx, txHash)
+	if err != nil {
+		return types.Vout{}, err
+	}
+	if int(vout) >= len(tx.Vout) {
+		return types.Vout{}, fmt.Errorf("output %d not found in transaction %s", vout, txHash)
+	}
+	return tx.Vout[vout], nil
+}
+
 // GetBlock returns block information
 func (client *Client) GetBlock(ctx context.Context, block uint64) (types.Block, error) {
 	return client.GetBlockWithOptions(ctx, block, map[string]interface{}{"page": 1})

--- a/chain/bitcoin/client/rest/endpoints.go
+++ b/chain/bitcoin/client/rest/endpoints.go
@@ -83,6 +83,17 @@ func (client *Client) GetTx(ctx context.Context, txHash string) (types.Transacti
 	return data, nil
 }
 
+func (client *Client) GetOutput(ctx context.Context, txHash string, vout uint32) (types.Vout, error) {
+	tx, err := client.GetTx(ctx, txHash)
+	if err != nil {
+		return types.Vout{}, err
+	}
+	if int(vout) >= len(tx.Vout) {
+		return types.Vout{}, fmt.Errorf("output %d not found in transaction %s", vout, txHash)
+	}
+	return tx.Vout[vout], nil
+}
+
 func (client *Client) GetBlock(ctx context.Context, block uint64) (types.Block, error) {
 	var data types.Block
 	err := client.get(ctx, fmt.Sprintf("/api/v2/block/%d", block), &data)

--- a/chain/bitcoin/client/rpc/endpoints.go
+++ b/chain/bitcoin/client/rpc/endpoints.go
@@ -357,6 +357,10 @@ func (client *Client) GetTx(ctx context.Context, txid string) (types.Transaction
 	return response, nil
 }
 
+func (client *Client) GetOutput(ctx context.Context, txid string, vout uint32) (types.Vout, error) {
+	return client.bbClient.GetOutput(ctx, txid, vout)
+}
+
 func (client *Client) ListUtxo(ctx context.Context, addr string, confirmed bool) (types.UtxoResponse, error) {
 	return client.bbClient.ListUtxo(ctx, addr, confirmed)
 }

--- a/chain/bitcoin/client/types/types.go
+++ b/chain/bitcoin/client/types/types.go
@@ -28,6 +28,7 @@ type BitcoinClientDriver interface {
 	LatestBlock(ctx context.Context) (uint64, error)
 	SubmitTx(ctx context.Context, txBytes []byte) (string, error)
 	GetTx(ctx context.Context, txHash string) (TransactionResponse, error)
+	GetOutput(ctx context.Context, txHash string, vout uint32) (Vout, error)
 	GetBlock(ctx context.Context, block uint64) (Block, error)
 }
 

--- a/chain/bitcoin/tx/tx.go
+++ b/chain/bitcoin/tx/tx.go
@@ -194,10 +194,11 @@ func (tx *Tx) SetSignatures(signatureResponses ...*xc.SignatureResponse) error {
 			tx.MsgTx.TxIn[i].Witness = wire.TxWitness([][]byte{signatureWithSuffix, signatureResponses[i].PublicKey})
 		} else {
 			log.Debug("append signature (legacy)")
-			// Support non-segwit
 			builder := txscript.NewScriptBuilder()
 			builder.AddData(signatureWithSuffix)
-			builder.AddData(signatureResponses[i].PublicKey)
+			if !txscript.IsPayToPubKey(pubKeyScript) {
+				builder.AddData(signatureResponses[i].PublicKey)
+			}
 			tx.MsgTx.TxIn[i].SignatureScript, err = builder.Script()
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary
- fetch and retain the actual scriptPubKey for every DOGE UTXO
- build a signature-only unlock script for legacy P2PK prevouts
- retain the existing signature-plus-public-key behavior for P2PKH

## Root cause
The DOGE UTXO loader synthesized P2PKH scripts from the address for every input. A P2PK prevout then received an extra public-key push in its scriptSig; during OP_CHECKSIG Dogecoin interpreted that pushed public key as the signature and rejected it as non-canonical DER.

## Validation
- regression test for a P2PK input verifies a single signature push
- go test -mod=readonly -tags not_ci ./...
- read-only mainnet DOGE input fetch verified actual prevout-script lookup through the configured indexer