### PR TITLE
solana: fix durable-nonce false positive on zero fee-payer account

### DIFF
--- a/chain/solana/client/client.go
+++ b/chain/solana/client/client.go
@@ -289,6 +289,33 @@ func (client *Client) FetchTransferInput(ctx context.Context, args xcbuilder.Tra
 		}
 	}
 
+	// Workaround for a durable-nonce bug in already-deployed clients that we
+	// cannot patch remotely (fixed by the guard in doesTxUseDurableNonce, see
+	// https://github.com/cordialsys/crosschain/pull/258):
+	//
+	// When the fee-payer feature is excluded, FeePayerDurableNonceAccount stays
+	// zero, which equals the System Program (11111111111111111111111111111111).
+	// The System Program is referenced by nearly every transaction, so the
+	// deployed doesTxUseDurableNonce/SetCall reports a false "uses our durable
+	// nonce" match, fabricates a durable nonce from the tx blockhash, and
+	// produces phantom conflicts in IndependentOf.
+	//
+	// Mirroring the from-address durable nonce into the fee-payer fields makes
+	// that probe hit a real account instead of the zero pubkey, which dodges the
+	// bug. Because the mirrored values are identical to the from-address nonce,
+	// this is transparent to the deployed builder (self-pay ignores the
+	// fee-payer fields; a separate fee-payer resolves to the same account,
+	// nonce, and authority) and to conflict detection (EffectiveDurableNonceState
+	// is unchanged). Only mirror when a from-address durable nonce is actually
+	// set -- otherwise the account stays zero and the fabricated nonce is
+	// already harmless (MatchDurableNonce short-circuits on a zero account).
+	if client.Asset.ExcludeFeatures && !txInput.DurableNonceAccount.IsZero() {
+		txInput.FeePayerDurableNonceAccount = txInput.DurableNonceAccount
+		txInput.FeePayerDurableNonceAuthority = txInput.DurableNonceAuthority
+		txInput.FeePayerDurableNonce = txInput.DurableNonce
+		txInput.ShouldCreateFeePayerNonce = txInput.ShouldCreateDurableNonce
+	}
+
 	if contract == "" {
 		// native transfer
 		return client.WithTransferSimulation(ctx, args, txInput)

--- a/chain/solana/client/client_test.go
+++ b/chain/solana/client/client_test.go
@@ -600,6 +600,111 @@ func TestFetchTransferInputRejectsManualNonceAccountWithUnexpectedAuthority(t *t
 	require.ErrorContains(t, err, "does not match from address 4ixwJt7DDGUV3xxi3mvZuEjLn4kDC39ogknnHQ4Crv5a or fee payer address 21yrAb33AQtNB43XWm2X9uKMXnTq8u9Wpzxzn8ZHEZBu")
 }
 
+// When ExcludeFeatures is set, the fee-payer durable nonce is intentionally
+// left unset. To dodge a durable-nonce bug in already-deployed clients (see
+// https://github.com/cordialsys/crosschain/pull/258), FetchTransferInput
+// mirrors the from-address durable nonce into the fee-payer fields so the
+// deployed doesTxUseDurableNonce probe hits a real account instead of the
+// zero pubkey (== System Program).
+func TestFetchTransferInputMirrorsDurableNonceWhenFeaturesExcluded(t *testing.T) {
+	// blockhash, rent, native balance (affords rent), missing nonce (=> create), simulate
+	balanceResponse := `{"context":{"slot":83986105},"value":5000000}`
+	simulateResponse := `{"jsonrpc":"2.0","result":{"value": {"unitsConsumed": 150,"logs": [],"accounts": null},"context": {"slot": 328286226}},"id":1}`
+	server, close := testtypes.MockJSONRPC(t, []string{
+		solanaValidBlockhashResponse,
+		solanaRentExemptionResponse,
+		balanceResponse,
+		solanaMissingNonceAccountResponse,
+		simulateResponse,
+	})
+	defer close()
+
+	asset := xc.NewChainConfig("")
+	asset.URL = server.URL
+	asset.ExcludeFeatures = true
+	solClient, err := client.NewClient(asset)
+	require.NoError(t, err)
+
+	from := xc.Address("4ixwJt7DDGUV3xxi3mvZuEjLn4kDC39ogknnHQ4Crv5a")
+	feePayer := xc.Address("21yrAb33AQtNB43XWm2X9uKMXnTq8u9Wpzxzn8ZHEZBu")
+	to := xc.Address("Hzn3n914JaSpnxo5mBbmuCDmGL6mxWN9Ac2HzEXFSGtb")
+	fromPub := solana.MustPublicKeyFromBase58(string(from))
+	expectedNonceAccount, err := client.DeriveNonceAccount(fromPub)
+	require.NoError(t, err)
+
+	args := buildertest.MustNewTransferArgs(
+		asset.Base(),
+		from,
+		to,
+		xc.NewAmountBlockchainFromUint64(1),
+		buildertest.OptionFeePayer(feePayer, nil),
+	)
+	input, err := solClient.FetchTransferInput(context.Background(), args)
+	require.NoError(t, err)
+
+	txInput := input.(*TxInput)
+	// From-address durable nonce is set.
+	require.Equal(t, expectedNonceAccount, txInput.DurableNonceAccount)
+	require.Equal(t, fromPub, txInput.DurableNonceAuthority)
+	require.True(t, txInput.ShouldCreateDurableNonce)
+
+	// Fee-payer fields are mirrored from the from-address durable nonce, so the
+	// deployed doesTxUseDurableNonce probe never sees a zero account.
+	require.False(t, txInput.FeePayerDurableNonceAccount.IsZero())
+	require.Equal(t, txInput.DurableNonceAccount, txInput.FeePayerDurableNonceAccount)
+	require.Equal(t, txInput.DurableNonceAuthority, txInput.FeePayerDurableNonceAuthority)
+	require.Equal(t, txInput.DurableNonce, txInput.FeePayerDurableNonce)
+	require.Equal(t, txInput.ShouldCreateDurableNonce, txInput.ShouldCreateFeePayerNonce)
+
+	// Mirroring must leave conflict detection unchanged: the effective state of
+	// the mirrored input must match the same input without the fee-payer fields.
+	notMirrored := *txInput
+	notMirrored.FeePayerDurableNonceAccount = solana.PublicKey{}
+	notMirrored.FeePayerDurableNonceAuthority = solana.PublicKey{}
+	notMirrored.FeePayerDurableNonce = solana.Hash{}
+	notMirrored.ShouldCreateFeePayerNonce = false
+	require.Equal(t,
+		notMirrored.EffectiveDurableNonceState(),
+		txInput.EffectiveDurableNonceState(),
+	)
+}
+
+// Without ExcludeFeatures and without a fee payer, the fee-payer nonce fields
+// stay unset (the mirror is gated behind ExcludeFeatures).
+func TestFetchTransferInputDoesNotMirrorByDefault(t *testing.T) {
+	balanceResponse := `{"context":{"slot":83986105},"value":5000000}`
+	simulateResponse := `{"jsonrpc":"2.0","result":{"value": {"unitsConsumed": 150,"logs": [],"accounts": null},"context": {"slot": 328286226}},"id":1}`
+	server, close := testtypes.MockJSONRPC(t, []string{
+		solanaValidBlockhashResponse,
+		solanaRentExemptionResponse,
+		balanceResponse,
+		solanaMissingNonceAccountResponse,
+		simulateResponse,
+	})
+	defer close()
+
+	asset := xc.NewChainConfig("")
+	asset.URL = server.URL
+	solClient, err := client.NewClient(asset)
+	require.NoError(t, err)
+
+	from := xc.Address("4ixwJt7DDGUV3xxi3mvZuEjLn4kDC39ogknnHQ4Crv5a")
+	to := xc.Address("Hzn3n914JaSpnxo5mBbmuCDmGL6mxWN9Ac2HzEXFSGtb")
+
+	args := buildertest.MustNewTransferArgs(
+		asset.Base(),
+		from,
+		to,
+		xc.NewAmountBlockchainFromUint64(1),
+	)
+	input, err := solClient.FetchTransferInput(context.Background(), args)
+	require.NoError(t, err)
+
+	txInput := input.(*TxInput)
+	require.False(t, txInput.DurableNonceAccount.IsZero())
+	require.True(t, txInput.FeePayerDurableNonceAccount.IsZero())
+}
+
 func TestSubmitTxSuccess(t *testing.T) {
 	txbin := "01df5ff457c2cdd23242ab26edd0b308d78499f28c6d43e185149cacdb88b35db171f1779e48ce2224cc80b9b9ce46dd80758319068b08eae34b14dc2cd070ab000100010379726da52d99d60b07ead73b2f6f0bf6083cc85c77a94e34d691d78f8bcafec9fc880863219008406235fa4c8fbb2a86d3da7b6762eac39323b2a1d8c404a4140000000000000000000000000000000000000000000000000000000000000000932bbef1569d58f4a116f41028f766439b2ba52c68c3308bbbea2b21e4716f6701020200010c0200000000ca9a3b00000000"
 	bytes, _ := hex.DecodeString(txbin)

--- a/chain/solana/tx_input/tx_input.go
+++ b/chain/solana/tx_input/tx_input.go
@@ -148,6 +148,13 @@ func (input *TxInput) doesTxUseDurableNonce(tx *solana.Transaction, account sola
 	if tx.Message.RecentBlockhash.Equals(nonce) && !nonce.IsZero() {
 		return true
 	}
+	// A zero account means this durable-nonce slot isn't configured.  The zero
+	// pubkey is the System Program (11111111111111111111111111111111), which is
+	// referenced by nearly every transaction, so matching on it would produce a
+	// false positive.
+	if account.IsZero() {
+		return false
+	}
 	usingDurableNonce := false
 	for _, accountKey := range tx.Message.AccountKeys {
 		if account.Equals(accountKey) {

--- a/chain/solana/tx_input/tx_input_test.go
+++ b/chain/solana/tx_input/tx_input_test.go
@@ -1,6 +1,7 @@
 package tx_input
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -379,4 +380,56 @@ func TestTxInputGetFeeLimit(t *testing.T) {
 			require.Equal(t, xc.ContractAddress(""), contract)
 		})
 	}
+}
+
+// Regression test: when no fee-payer durable nonce is configured, its account
+// is the zero pubkey, which equals the System Program
+// (11111111111111111111111111111111) referenced by nearly every transaction.
+// SetCall must not treat that spurious match as "the tx uses our durable
+// nonce" and overwrite the from-address DurableNonce with the tx blockhash.
+// Doing so previously made two inputs with genuinely different nonces look
+// like they shared one, producing a false conflict in IndependentOf.
+func TestSetCallDoesNotPatchNonceOnZeroFeePayerAccount(t *testing.T) {
+	// A real transaction whose message blockhash (9pKQ...) is NOT the input's
+	// configured durable nonce (81Hmv...) and which does not reference the
+	// configured nonce account (4jkCK8...). The only place the zero fee-payer
+	// account can match is the System Program in the account keys.
+	raw := "0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010009112d2474fe017fa4d19075e29cee436b1620b0dfee0cfb3e9615419467a16b686f3cf6e24a5ecef0e419110de68a7980aea260a7528617545dcad4b634fe92ce0a47f570eaa98fd393d987f7dd0cb87e344844d815b9d85ad4fb5cf36fb8194567a07c0f46a8370e410f5bf99110112d87c39ebd4ca091d0087e18460f14c82308b9f8a2e9eb369bc74465344d747057de1707c20d7c04398de36442eea2cc7578e098d13b3f004b629962270389482099749095cf9dc546be654b808800c6827cea5dc2c7f5c1147ee76ad644fbbbde015b52d6e31ae1bdbfe447958f19f4b06df6ced3a6c28b94986c2c8e55c0e65474f37eeae7f9087a1ed84c264b7c683a72000000000000000000000000000000000000000000000000000000000000000006a7d517192c568ee08a845f73d29788cf035c3145b21ab344d8062ea940000006ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a906ddf6e1ee758fde18425dbce46ccddab61afc4d83b90d27febdf928d8a18bfc17f34b976beaede1328778fe0fd0a5ce7d8cddfd565d13362ea2f53b7853160f8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f859967825584cf812fec6b0593544e60c2f569c376deeb55d5f05348f9034fe6ded9b7a381c205fb8d80f44977e9697e6e4aa7af080c00f36652c3d8075a32c073bd9bba49e0fdeb3a01c108d86981ebb337e18bcf3e15fe0800e1631c9d09675d882fc98ec93da7d4d0aea71f2d35dd8de43e4aa11a67abd2888bc179138c19dd1020803060900040400000010100c0000000e0f0307050204010a0b0d0810e171c4a7a8b4287700e8764817000000"
+	bz, err := hex.DecodeString(raw)
+	require.NoError(t, err)
+	tx, err := solana.TransactionFromBytes(bz)
+	require.NoError(t, err)
+
+	nonceAccount := solana.MustPublicKeyFromBase58("4jkCK8vpn3HdXicNLfvYWNPvBphxea3bB4YGdYvifm9A")
+	nonceAuthority := solana.MustPublicKeyFromBase58("43DbAvKxhXh1oSxkJSqGosNw3HpBnmsWiak6tB5wpecN")
+
+	newInput := &CallInput{
+		TxInput: TxInput{
+			DurableNonce:          solana.MustHashFromBase58("81HmvTjKHtM5xjcntqkDpnfaoLzZJJFX5Tv9UZ9bFGz4"),
+			DurableNonceAccount:   nonceAccount,
+			DurableNonceAuthority: nonceAuthority,
+			BaseFee:               xc.NewAmountBlockchainFromUint64(5000),
+			FeePayerBaseFee:       xc.NewAmountBlockchainFromUint64(5000),
+		},
+	}
+
+	require.NoError(t, newInput.SetCall(NewCallPayload(tx)))
+
+	// The tx does not actually use the configured durable nonce, so SetCall
+	// should NOT have patched DurableNonce to the tx's blockhash.
+	require.NotEqual(t,
+		solana.MustHashFromBase58("9pKQ9Z8yQDSKDp651R5N7bag1QpGiPqu1fDPyzzf2gue"),
+		newInput.DurableNonce,
+		"DurableNonce must not be overwritten with the tx blockhash",
+	)
+
+	// An older transaction using the same nonce account with a different nonce
+	// value must remain independent (each uses its own nonce value).
+	oldInput := &TxInput{
+		DurableNonce:          solana.MustHashFromBase58("9pKQ9Z8yQDSKDp651R5N7bag1QpGiPqu1fDPyzzf2gue"),
+		DurableNonceAccount:   nonceAccount,
+		DurableNonceAuthority: nonceAuthority,
+		PrioritizationFee:     xc.NewAmountBlockchainFromUint64(447930),
+	}
+	require.True(t, newInput.IndependentOf(oldInput), "inputs with different nonces must be independent")
 }


### PR DESCRIPTION
## Problem

A user reported that a Solana call transaction was flagged as conflicting with an older transaction (`TxInput.IndependentOf` returned `false`), even though the two inputs used **different** durable nonces on the same nonce account — which should be independent.

## Root cause

The conflict itself is a phantom created *before* `IndependentOf` runs, inside `CallInput.SetCall`:

1. When a transaction has no fee-payer durable nonce configured, its fee-payer nonce account is the **zero pubkey**, which is the System Program `11111111111111111111111111111111`.
2. Nearly every Solana transaction references the System Program in its account keys, so the account-key scan in `doesTxUseDurableNonce` spuriously matched it and reported "this tx uses our durable nonce" via `DoesTxUseOurDurableNonce`.
3. `SetCall` then overwrote the from-address `DurableNonce` with the transaction's recent blockhash.
4. In the reported case that blockhash happened to equal the *older* transaction's durable nonce, so the two inputs looked like they shared a nonce and `MatchDurableNonce` reported `sameNonce=true` → `IndependentOf` returned `false`.

The nonce-value check already guarded against a zero *nonce* (`&& !nonce.IsZero()`), but the account-key loop had no equivalent guard for a zero *account*.

## Fix

Guard `doesTxUseDurableNonce` against a zero account, mirroring the existing zero-nonce guard.

## Test

Added `TestSetCallDoesNotPatchNonceOnZeroFeePayerAccount`, built from the exact transaction the user reported. It fails on `main` (nonce gets patched → false conflict) and passes with the fix. Full `chain/solana/...` suite is green.