### PR TITLE
filecoin: archival secondary_url fallback for tx-info

### DIFF
--- a/chain/filecoin/client/client.go
+++ b/chain/filecoin/client/client.go
@@ -293,7 +293,7 @@ func (client *Client) fetchTxInfo(ctx context.Context, args *txinfo.Args) (txinf
 	movement := txinfo.NewMovement(chain, "")
 	amount := xc.NewAmountBlockchainFromStr(msg.Value)
 	movement.AddSource(xc.Address(msg.From), amount, nil)
-	movement.AddDestination(sourceAddress, amount, nil)
+	movement.AddDestination(xc.Address(msg.To), amount, nil)
 	txInfo.AddMovement(movement)
 
 	gasLimit, ok := xc.NewAmountBlockchainFromInt64(int64(msg.GasLimit))

--- a/chain/filecoin/client/client.go
+++ b/chain/filecoin/client/client.go
@@ -202,6 +202,24 @@ func (client *Client) ConvertEvmHashToCid(txHash xc.TxHash) (xc.TxHash, error) {
 // There is a small penalty for overestimating the gas limit, which is not included in calculations
 // at the moment
 func (client *Client) FetchTxInfo(ctx context.Context, args *txinfo.Args) (txinfo.TxInfo, error) {
+	info, err := client.fetchTxInfo(ctx, args)
+	if err != nil {
+		// The primary RPC may not retain enough history to resolve an older
+		// transaction (many providers only serve ~24h of state).  If a
+		// `secondary_url` is configured (e.g. an archival endpoint), retry there.
+		secondaryUrl := client.Asset.GetChain().SecondaryURL
+		if secondaryUrl != "" && secondaryUrl != client.Url {
+			client.Logger.WithField("secondary_url", secondaryUrl).WithError(err).
+				Warn("primary tx-info lookup failed, retrying with secondary_url")
+			secondary := *client
+			secondary.Url = secondaryUrl
+			return secondary.fetchTxInfo(ctx, args)
+		}
+	}
+	return info, err
+}
+
+func (client *Client) fetchTxInfo(ctx context.Context, args *txinfo.Args) (txinfo.TxInfo, error) {
 	txHash := args.TxHash()
 	isEvmHash := strings.HasPrefix(string(txHash), "0x")
 	if isEvmHash {
@@ -262,7 +280,7 @@ func (client *Client) FetchTxInfo(ctx context.Context, args *txinfo.Args) (txinf
 	chain := chainCfg.Chain
 	sHash := string(txHash)
 	blockData := chainGetBlockResponse.Result
-	block := txinfo.NewBlock(chain, blockData.Height, sHash, time.MillisFromInt64(blockData.Timestamp).ToTime())
+	block := txinfo.NewBlock(chain, blockData.Height, sHash, time.MillisFromSeconds(blockData.Timestamp).ToTime())
 	confirmations := chainHeadHeight - block.Height.Uint64()
 	var errorMsg *string
 	if msgState.Receipt.ExitCode != 0 {
@@ -383,7 +401,7 @@ func (client *Client) FetchBlock(ctx context.Context, args *xclient.BlockArgs) (
 	if err != nil {
 		return &txinfo.BlockWithTransactions{}, fmt.Errorf("failed to get block: %w", err)
 	}
-	blockTimestamp := time.MillisFromInt64(chainGetBlockResponse.Result.Timestamp)
+	blockTimestamp := time.MillisFromSeconds(chainGetBlockResponse.Result.Timestamp)
 
 	parentHash := chainGetBlockResponse.Result.Parents[0]
 	block := txinfo.NewBlock(client.Asset.GetChain().Chain, height, parentHash.Value, blockTimestamp.ToTime())
@@ -410,6 +428,10 @@ func Post[P any, R any](client *Client, params types.Params[P], response *types.
 		return fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 	request.Header.Set("Content-Type", "application/json")
+	// Some Filecoin RPC providers (e.g. explorer-hosted archival nodes like filfox)
+	// reject the default Go http client User-Agent with a 403.  Send an identifying
+	// User-Agent so these endpoints are usable, notably as a `secondary_url` backup.
+	request.Header.Set("User-Agent", "cordialsys-crosschain")
 
 	logger.WithField("payload", string(payload)).Debug("sending request")
 	resp, err := client.HttpClient.Do(request)

--- a/chain/filecoin/client/client_test.go
+++ b/chain/filecoin/client/client_test.go
@@ -368,7 +368,7 @@ func TestFetchTxInfo(t *testing.T) {
 					Chain:  xc.NativeAsset("FIL"),
 					Height: xc.NewAmountBlockchainFromUint64(2440037),
 					Hash:   "bafy2bzacedza344ak7eol4uydlwddlj6igiseftbaomafc3iscsmzoslo65vc",
-					Time:   MustParseTime("1970-01-21T03:28:47.49Z"),
+					Time:   MustParseTime("2025-02-25T23:51:30Z"),
 				},
 				Movements: []*txinfo.Movement{
 					NewMovement(
@@ -466,7 +466,7 @@ func TestFetchTxInfo(t *testing.T) {
 					Chain:  xc.NativeAsset("FIL"),
 					Height: xc.NewAmountBlockchainFromUint64(2440037),
 					Hash:   "bafy2bzacedza344ak7eol4uydlwddlj6igiseftbaomafc3iscsmzoslo65vc",
-					Time:   MustParseTime("1970-01-21T03:28:47.49Z"),
+					Time:   MustParseTime("2025-02-25T23:51:30Z"),
 				},
 				Movements: []*txinfo.Movement{
 					NewMovement(

--- a/chain/filecoin/client/client_test.go
+++ b/chain/filecoin/client/client_test.go
@@ -383,8 +383,8 @@ func TestFetchTxInfo(t *testing.T) {
 						},
 						[]*txinfo.BalanceChange{{
 							Balance:   xc.NewAmountBlockchainFromUint64(100000000000000000),
-							XAddress:  "chains/FIL/addresses/f13uhmulxtag3qfohj7h2nmtco7e7u3t3nxjdzi7q",
-							AddressId: "f13uhmulxtag3qfohj7h2nmtco7e7u3t3nxjdzi7q",
+							XAddress:  "chains/FIL/addresses/f1urvqy4hx5idlki6b6f7ab6hzihjdfy47b5cc6dy",
+							AddressId: "f1urvqy4hx5idlki6b6f7ab6hzihjdfy47b5cc6dy",
 						}},
 						nil,
 					),
@@ -481,8 +481,8 @@ func TestFetchTxInfo(t *testing.T) {
 						},
 						[]*txinfo.BalanceChange{{
 							Balance:   xc.NewAmountBlockchainFromUint64(100000000000000000),
-							XAddress:  "chains/FIL/addresses/f13uhmulxtag3qfohj7h2nmtco7e7u3t3nxjdzi7q",
-							AddressId: "f13uhmulxtag3qfohj7h2nmtco7e7u3t3nxjdzi7q",
+							XAddress:  "chains/FIL/addresses/f1urvqy4hx5idlki6b6f7ab6hzihjdfy47b5cc6dy",
+							AddressId: "f1urvqy4hx5idlki6b6f7ab6hzihjdfy47b5cc6dy",
 						}},
 						nil,
 					),


### PR DESCRIPTION
## Problem

`tx-info` for Filecoin fails with `transaction not found` for any transaction older than the primary RPC's history window. Most hosted FIL RPCs (including the Ankr endpoint in our mainnet config) only retain ~24h of state, so `StateSearchMsg` returns null for older transfers even though the transaction is real and final.

Discovered while investigating why a real ~25-day-old transfer (`bafy2bzaced2qggi...`, 45,804 FIL) couldn't be looked up.

## Changes

- **`secondary_url` fallback for `FetchTxInfo`**: when the primary RPC fails, retry the same standard Lotus flow against the configured `secondary_url` (intended to be a fully-archival endpoint). No new driver/schema code — it reuses the existing client against a second URL.
- **User-Agent header**: some explorer-hosted archival nodes (e.g. filfox) `403` the default `Go-http-client` User-Agent. We now send an identifying `cordialsys-crosschain` UA so these endpoints work — notably as the archival backup.
- **Timestamp bug fix**: FIL block timestamps are Unix **seconds** but were parsed with `MillisFromInt64`, producing 1970 dates. Fixed in both `FetchTxInfo` and `FetchBlock` (`MillisFromSeconds`); test expectations corrected.
- **Destination bug fix**: the transfer movement's destination was set to the source address instead of `msg.To`, so tx-info reported the sender as both `from` and `to`. Now uses the actual recipient.

## Verification

End-to-end via `.envrc-mainnet` with the existing non-archival Ankr primary + `secondary_url: https://filfox.info/rpc/v1`:

```
WARN primary tx-info lookup failed, retrying with secondary_url  error="transaction not found"
transfer from: f1kclrt3t7y7c2ni467vcv4xddno46vlj2fvtsu7q
transfer to:   f1775wdism7ipwnzyhkvmqrg5bsfmfr4eihxeiiyi   # was reporting the sender
amount:        45804418655320000000000
"state": "succeeded"   "height": "6126521"   "time": "2026-06-22T04:20:30Z"
"confirmations": 73168
```

`go test ./chain/filecoin/...` passes.

Companion config PR in `services` sets the FIL `secondary_url`.