### PR TITLE
zec: handle t3 and unknown address types

### DIFF
--- a/chain/bitcoin/builder/builder.go
+++ b/chain/bitcoin/builder/builder.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	xc "github.com/cordialsys/crosschain"
 	xcbuilder "github.com/cordialsys/crosschain/builder"
@@ -202,7 +201,7 @@ func (txBuilder TxBuilder) MultiTransfer(args xcbuilder.MultiTransferArgs, input
 		if err != nil {
 			return nil, err
 		}
-		script, err := txscript.PayToAddrScript(addr)
+		script, err := txBuilder.AddressDecoder.PayToAddrScript(addr)
 		if err != nil {
 			logrus.WithError(err).WithField("to", recipient.To).Error("trying paytoaddr")
 			return nil, err

--- a/chain/bitcoin/client/rpc/endpoints.go
+++ b/chain/bitcoin/client/rpc/endpoints.go
@@ -277,23 +277,31 @@ func (client *Client) GetTx(ctx context.Context, txid string) (types.Transaction
 		}
 
 		// Extract addresses from the scriptPubKey
-		_, extracted, _, err := txscript.ExtractPkScriptAddrs(scriptPubKey, client.chaincfg)
+		scriptClass, extracted, _, err := txscript.ExtractPkScriptAddrs(scriptPubKey, client.chaincfg)
 		if err != nil {
 			return types.TransactionResponse{}, fmt.Errorf("failed to extract addresses from scriptPubKey: %w", err)
 		}
 		// Convert addresses to strings
 		for _, addr := range extracted {
 			if client.chain.Chain == xc.ZEC {
-				tadr := zecaddress.TransparentAddress{
-					Hash:         [20]byte(addr.ScriptAddress()),
-					NetID:        client.chaincfg.PubKeyHashAddrID,
-					ScriptHashId: client.chaincfg.ScriptHashAddrID,
+				var addressType zecaddress.TransparentAddressType
+				switch scriptClass {
+				case txscript.PubKeyHashTy:
+					addressType = zecaddress.TransparentAddressPubKeyHash
+				case txscript.ScriptHashTy:
+					addressType = zecaddress.TransparentAddressScriptHash
+				default:
+					addresses = append(addresses, addr.String())
+					continue
 				}
-				addresses = append(addresses, tadr.EncodeAddress())
+				taddr, err := zecaddress.NewTransparentAddress(addr.ScriptAddress(), addressType, client.chaincfg)
+				if err != nil {
+					return types.TransactionResponse{}, fmt.Errorf("failed to encode zcash transparent address: %w", err)
+				}
+				addresses = append(addresses, taddr.EncodeAddress())
 			} else {
 				addresses = append(addresses, addr.String())
 			}
-			addresses = append(addresses, addr.String())
 		}
 		amount := vout.Value.ToBlockchain(decimals)
 

--- a/chain/zcash/address/decoder.go
+++ b/chain/zcash/address/decoder.go
@@ -2,6 +2,7 @@ package address
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/base58"
@@ -20,11 +21,35 @@ func NewAddressDecoder() *ZcashAddressDecoder {
 
 var _ bitcoinaddress.AddressDecoder = &ZcashAddressDecoder{}
 
-// "t" Address
+type TransparentAddressType uint8
+
+const (
+	TransparentAddressPubKeyHash TransparentAddressType = iota
+	TransparentAddressScriptHash
+)
+
+type Params struct {
+	PubKeyHashPrefix [2]byte
+	ScriptHashPrefix [2]byte
+}
+
+var (
+	mainnetParams = Params{
+		PubKeyHashPrefix: [2]byte{0x1C, 0xB8},
+		ScriptHashPrefix: [2]byte{0x1C, 0xBD},
+	}
+	testnetParams = Params{
+		PubKeyHashPrefix: [2]byte{0x1D, 0x25},
+		ScriptHashPrefix: [2]byte{0x1C, 0xBA},
+	}
+)
+
+// TransparentAddress is a Zcash transparent P2PKH or P2SH address.
 type TransparentAddress struct {
 	Hash         [ripemd160.Size]byte
 	NetID        byte
 	ScriptHashId byte
+	Type         TransparentAddressType
 }
 
 var _ btcutil.Address = &TransparentAddress{}
@@ -39,7 +64,19 @@ func (t *TransparentAddress) ScriptAddress() []byte {
 }
 
 func (t *TransparentAddress) IsForNet(net *chaincfg.Params) bool {
-	return t.NetID == net.PubKeyHashAddrID
+	params, err := transparentAddressParams(net)
+	if err != nil {
+		return false
+	}
+	prefix := [2]byte{t.NetID, t.ScriptHashId}
+	switch t.Type {
+	case TransparentAddressPubKeyHash:
+		return prefix == params.PubKeyHashPrefix
+	case TransparentAddressScriptHash:
+		return prefix == params.ScriptHashPrefix
+	default:
+		return false
+	}
 }
 
 func (t *TransparentAddress) String() string {
@@ -49,14 +86,20 @@ func (t *TransparentAddress) String() string {
 func (*ZcashAddressDecoder) PayToAddrScript(addr btcutil.Address) ([]byte, error) {
 	switch addr := addr.(type) {
 	case *TransparentAddress:
-		return payToPubKeyHashScript(addr.ScriptAddress())
+		switch addr.Type {
+		case TransparentAddressPubKeyHash:
+			return payToPubKeyHashScript(addr.ScriptAddress())
+		case TransparentAddressScriptHash:
+			return payToScriptHashScript(addr.ScriptAddress())
+		default:
+			return nil, errors.New("unsupported zcash transparent address type")
+		}
 	default:
 		return nil, errors.New("unsupported zcash address type")
 	}
 }
 
 func (*ZcashAddressDecoder) Decode(inputAddr xc.Address, params *chaincfg.Params) (btcutil.Address, error) {
-	// Switch on decoded length to determine the type.
 	addr := string(inputAddr)
 	decoded, netID, err := base58.CheckDecode(addr)
 	if err != nil {
@@ -65,20 +108,72 @@ func (*ZcashAddressDecoder) Decode(inputAddr xc.Address, params *chaincfg.Params
 		}
 		return nil, errors.New("decoded address is of unknown format")
 	}
-	scriptHashId := decoded[0]
-	decoded = decoded[1:]
-	switch len(decoded) {
-	case ripemd160.Size:
-		// Can only be a transparent address
-		hash := [ripemd160.Size]byte{}
-		copy(hash[:], decoded)
-		return &TransparentAddress{
-			Hash:         hash,
-			NetID:        netID,
-			ScriptHashId: scriptHashId,
-		}, nil
-	default:
+	if len(decoded) != ripemd160.Size+1 {
 		return nil, errors.New("decoded zcash address is of unknown size")
+	}
+
+	transparentParams, err := transparentAddressParams(params)
+	if err != nil {
+		return nil, err
+	}
+	prefix := [2]byte{netID, decoded[0]}
+	var addressType TransparentAddressType
+	switch prefix {
+	case transparentParams.PubKeyHashPrefix:
+		addressType = TransparentAddressPubKeyHash
+	case transparentParams.ScriptHashPrefix:
+		addressType = TransparentAddressScriptHash
+	default:
+		return nil, fmt.Errorf("unsupported zcash address prefix %x for %s", prefix, params.Name)
+	}
+
+	return NewTransparentAddress(decoded[1:], addressType, params)
+}
+
+func NewTransparentAddress(hash []byte, addressType TransparentAddressType, params *chaincfg.Params) (*TransparentAddress, error) {
+	if len(hash) != ripemd160.Size {
+		return nil, fmt.Errorf("invalid zcash transparent address hash length %d", len(hash))
+	}
+
+	transparentParams, err := transparentAddressParams(params)
+	if err != nil {
+		return nil, err
+	}
+	var prefix [2]byte
+	switch addressType {
+	case TransparentAddressPubKeyHash:
+		prefix = transparentParams.PubKeyHashPrefix
+	case TransparentAddressScriptHash:
+		prefix = transparentParams.ScriptHashPrefix
+	default:
+		return nil, fmt.Errorf("unsupported zcash transparent address type %d", addressType)
+	}
+
+	address := &TransparentAddress{
+		NetID:        prefix[0],
+		ScriptHashId: prefix[1],
+		Type:         addressType,
+	}
+	copy(address.Hash[:], hash)
+	return address, nil
+}
+
+// chaincfg only supports one-byte address prefixes. Zcash transparent addresses
+// have two-byte prefixes, so its params store the P2PKH prefix across the
+// PubKeyHashAddrID and ScriptHashAddrID fields.
+func transparentAddressParams(params *chaincfg.Params) (Params, error) {
+	if params == nil {
+		return Params{}, errors.New("zcash chain params are nil")
+	}
+
+	configuredPrefix := [2]byte{params.PubKeyHashAddrID, params.ScriptHashAddrID}
+	switch configuredPrefix {
+	case mainnetParams.PubKeyHashPrefix:
+		return mainnetParams, nil
+	case testnetParams.PubKeyHashPrefix:
+		return testnetParams, nil
+	default:
+		return Params{}, fmt.Errorf("unsupported zcash network parameters %x", configuredPrefix)
 	}
 }
 
@@ -86,5 +181,11 @@ func (*ZcashAddressDecoder) Decode(inputAddr xc.Address, params *chaincfg.Params
 func payToPubKeyHashScript(pubKeyHash []byte) ([]byte, error) {
 	return txscript.NewScriptBuilder().AddOp(txscript.OP_DUP).AddOp(txscript.OP_HASH160).
 		AddData(pubKeyHash).AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG).
+		Script()
+}
+
+func payToScriptHashScript(scriptHash []byte) ([]byte, error) {
+	return txscript.NewScriptBuilder().AddOp(txscript.OP_HASH160).
+		AddData(scriptHash).AddOp(txscript.OP_EQUAL).
 		Script()
 }

--- a/chain/zcash/address/decoder_test.go
+++ b/chain/zcash/address/decoder_test.go
@@ -1,0 +1,93 @@
+package address_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/base58"
+	"github.com/stretchr/testify/require"
+
+	xc "github.com/cordialsys/crosschain"
+	bitcoinparams "github.com/cordialsys/crosschain/chain/bitcoin/params"
+	"github.com/cordialsys/crosschain/chain/zcash/address"
+)
+
+func TestZcashAddressDecoderScripts(t *testing.T) {
+	tests := []struct {
+		name        string
+		network     string
+		encoded     xc.Address
+		addressType address.TransparentAddressType
+		script      string
+	}{
+		{
+			name:        "mainnet p2pkh",
+			network:     "mainnet",
+			encoded:     "t1NB5ugJ4ktDQcUP6fjPumKzfjJCdMmkM7v",
+			addressType: address.TransparentAddressPubKeyHash,
+			script:      "76a9142f2eddc4f91361f20797e00734662932fb5161c588ac",
+		},
+		{
+			name:        "mainnet p2sh regression",
+			network:     "mainnet",
+			encoded:     "t3Ns6qDnWJnXnhe5Xnq4WBxMbspVLtQpMtf",
+			addressType: address.TransparentAddressScriptHash,
+			script:      "a9142f2eddc4f91361f20797e00734662932fb5161c587",
+		},
+		{
+			name:        "testnet p2pkh",
+			network:     "testnet",
+			encoded:     "tmE1qEWnU9YiukiaYLTheczfRLHHSv5iGHP",
+			addressType: address.TransparentAddressPubKeyHash,
+			script:      "76a9142f2eddc4f91361f20797e00734662932fb5161c588ac",
+		},
+		{
+			name:        "testnet p2sh",
+			network:     "testnet",
+			encoded:     "t2ArHstteBF9AFLfGia4YjaYEzJiWrPX1fu",
+			addressType: address.TransparentAddressScriptHash,
+			script:      "a9142f2eddc4f91361f20797e00734662932fb5161c587",
+		},
+	}
+
+	decoder := address.NewAddressDecoder()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := xc.NewChainConfig(xc.ZEC).WithNet(tt.network)
+			params, err := bitcoinparams.GetParams(cfg.Base())
+			require.NoError(t, err)
+
+			decoded, err := decoder.Decode(tt.encoded, &params)
+			require.NoError(t, err)
+			transparent, ok := decoded.(*address.TransparentAddress)
+			require.True(t, ok)
+			require.Equal(t, tt.addressType, transparent.Type)
+			require.Equal(t, string(tt.encoded), transparent.EncodeAddress())
+			require.True(t, transparent.IsForNet(&params))
+
+			script, err := decoder.PayToAddrScript(transparent)
+			require.NoError(t, err)
+			require.Equal(t, tt.script, hex.EncodeToString(script))
+		})
+	}
+}
+
+func TestZcashAddressDecoderRejectsWrongNetworkAndUnknownPrefix(t *testing.T) {
+	decoder := address.NewAddressDecoder()
+	testnet := xc.NewChainConfig(xc.ZEC).WithNet("testnet")
+	testnetParams, err := bitcoinparams.GetParams(testnet.Base())
+	require.NoError(t, err)
+
+	_, err = decoder.Decode("t3Ns6qDnWJnXnhe5Xnq4WBxMbspVLtQpMtf", &testnetParams)
+	require.ErrorContains(t, err, "unsupported zcash address prefix")
+
+	hash, err := hex.DecodeString("2f2eddc4f91361f20797e00734662932fb5161c5")
+	require.NoError(t, err)
+	unknownPrefixAddress := base58.CheckEncode(append([]byte{0xB9}, hash...), 0x1C)
+	mainnet := xc.NewChainConfig(xc.ZEC).WithNet("mainnet")
+	mainnetParams, err := bitcoinparams.GetParams(mainnet.Base())
+	require.NoError(t, err)
+
+	_, err = decoder.Decode(xc.Address(unknownPrefixAddress), &mainnetParams)
+	require.ErrorContains(t, err, "unsupported zcash address prefix")
+}

--- a/chain/zcash/address/encoder.go
+++ b/chain/zcash/address/encoder.go
@@ -48,10 +48,9 @@ func (ab AddressBuilder) GetAddressFromPublicKey(publicKeyBytes []byte) (xc.Addr
 	publicKeyBytes = pubkey.SerializeCompressed()
 	hashBytes := [20]byte{}
 	copy(hashBytes[:], btcutil.Hash160(publicKeyBytes))
-	address := TransparentAddress{
-		Hash:         hashBytes,
-		NetID:        ab.params.PubKeyHashAddrID,
-		ScriptHashId: ab.params.ScriptHashAddrID,
+	address, err := NewTransparentAddress(hashBytes[:], TransparentAddressPubKeyHash, ab.params)
+	if err != nil {
+		return "", err
 	}
 
 	return xc.Address(address.EncodeAddress()), nil

--- a/chain/zcash/builder_test.go
+++ b/chain/zcash/builder_test.go
@@ -6,6 +6,7 @@ import (
 
 	xc "github.com/cordialsys/crosschain"
 	"github.com/cordialsys/crosschain/builder"
+	"github.com/cordialsys/crosschain/builder/buildertest"
 	"github.com/cordialsys/crosschain/chain/bitcoin/tx_input"
 	"github.com/cordialsys/crosschain/chain/zcash"
 	"github.com/stretchr/testify/require"
@@ -62,5 +63,72 @@ func TestTransfer(t *testing.T) {
 		// will have to update if anything changes in ZEC
 		"0400008085202f8901000000000b0930060201000201000100ffffffff0200e1f505000000001976a91442f9c388bff9d1f180388e5f644cc62d3864c06888ac00e1f505000000001976a914f37872277cd9210d5506f372e840c3da3ae11cf988ac00000000000000000000000000000000000000",
 		hex.EncodeToString(serialized),
+	)
+}
+
+func TestTransferToP2SH(t *testing.T) {
+	input := tx_input.NewTxInput()
+	input.UnspentOutputs = []tx_input.Output{
+		{
+			Value: xc.NewAmountBlockchainFromUint64(200000000),
+		},
+	}
+
+	cfg := xc.NewChainConfig(xc.ZEC).WithNet("mainnet")
+	txBuilder, err := zcash.NewTxBuilder(cfg.Base())
+	require.NoError(t, err)
+
+	from := xc.Address("t1g4xVgMHVsxZWxS6D3SLXNXEAicivXKiAS")
+	to := xc.Address("t3Ns6qDnWJnXnhe5Xnq4WBxMbspVLtQpMtf")
+	amount := xc.NewAmountBlockchainFromUint64(100000000)
+	args, err := builder.NewTransferArgs(cfg.Base(), from, to, amount)
+	require.NoError(t, err)
+
+	tx, err := txBuilder.Transfer(args, input)
+	require.NoError(t, err)
+	zcashTx, ok := tx.(*zcash.Tx)
+	require.True(t, ok)
+	require.Len(t, zcashTx.MsgTx.TxOut, 2)
+	require.Equal(t,
+		"a9142f2eddc4f91361f20797e00734662932fb5161c587",
+		hex.EncodeToString(zcashTx.MsgTx.TxOut[0].PkScript),
+	)
+}
+
+func TestMultiTransferToP2SH(t *testing.T) {
+	cfg := xc.NewChainConfig(xc.ZEC).WithNet("mainnet")
+	txBuilder, err := zcash.NewTxBuilder(cfg.Base())
+	require.NoError(t, err)
+
+	from := xc.Address("t1g4xVgMHVsxZWxS6D3SLXNXEAicivXKiAS")
+	to := xc.Address("t3Ns6qDnWJnXnhe5Xnq4WBxMbspVLtQpMtf")
+	amount := xc.NewAmountBlockchainFromUint64(100000000)
+	args, err := builder.NewMultiTransferArgs(
+		cfg.Base(),
+		[]*builder.Sender{buildertest.MustNewSender(from, nil)},
+		[]*builder.Receiver{buildertest.MustNewReceiver(to, amount)},
+	)
+	require.NoError(t, err)
+
+	input := tx_input.NewMultiTransferInput()
+	input.Inputs = []tx_input.TxInput{
+		{
+			Address: from,
+			UnspentOutputs: []tx_input.Output{
+				{
+					Value: xc.NewAmountBlockchainFromUint64(200000000),
+				},
+			},
+		},
+	}
+
+	tx, err := txBuilder.MultiTransfer(*args, input)
+	require.NoError(t, err)
+	zcashTx, ok := tx.(*zcash.Tx)
+	require.True(t, ok)
+	require.Len(t, zcashTx.MsgTx.TxOut, 2)
+	require.Equal(t,
+		"a9142f2eddc4f91361f20797e00734662932fb5161c587",
+		hex.EncodeToString(zcashTx.MsgTx.TxOut[0].PkScript),
 	)
 }

--- a/chain/zcash/validate_test.go
+++ b/chain/zcash/validate_test.go
@@ -35,6 +35,24 @@ func TestValidateAddress(t *testing.T) {
 			network:   "mainnet",
 			wantError: false,
 		},
+		{
+			name:      "Zcash - valid mainnet script address (t3)",
+			address:   "t3Ns6qDnWJnXnhe5Xnq4WBxMbspVLtQpMtf",
+			network:   "mainnet",
+			wantError: false,
+		},
+		{
+			name:      "Zcash - valid testnet pubkey address (tm)",
+			address:   "tmE1qEWnU9YiukiaYLTheczfRLHHSv5iGHP",
+			network:   "testnet",
+			wantError: false,
+		},
+		{
+			name:      "Zcash - valid testnet script address (t2)",
+			address:   "t2ArHstteBF9AFLfGia4YjaYEzJiWrPX1fu",
+			network:   "testnet",
+			wantError: false,
+		},
 		// Invalid addresses
 		{
 			name:      "Zcash - too short",
@@ -71,6 +89,12 @@ func TestValidateAddress(t *testing.T) {
 			name:      "Zcash - ethereum address",
 			address:   "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
 			network:   "mainnet",
+			wantError: true,
+		},
+		{
+			name:      "Zcash - mainnet address on testnet",
+			address:   "t3Ns6qDnWJnXnhe5Xnq4WBxMbspVLtQpMtf",
+			network:   "testnet",
 			wantError: true,
 		},
 	}


### PR DESCRIPTION

Test transfers:
- [Sweep to main XC address](https://mainnet.zcashexplorer.app/transactions/ee67d2883ab00f6cd8e81e0255c25971a355e79091771b01454d24781e043625)
- [Payment to test t3 address](https://mainnet.zcashexplorer.app/transactions/0e97963437c4bc0b861957993e400a2f2c9629e64d0e7bc322c195272f02814a)
- [Return from t3 address](https://mainnet.zcashexplorer.app/transactions/2bc3e4dfc5459ec984825025892ee21085c67248908627113116fa6f740d02b4)
- [Test t3 address](https://mainnet.zcashexplorer.app/address/t3aNi2ryPfRuwkhV13CdCzHgedJPFrazQEA)
- [Main XC address](https://mainnet.zcashexplorer.app/address/t1ddjnnCryEGv4gEopsJHBtn5w5vVnHtZWp)